### PR TITLE
feat(calendar): add event cancel confirmation dialog (#121)

### DIFF
--- a/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/plan.md
+++ b/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/plan.md
@@ -1,0 +1,19 @@
+# Event Cancel Confirmation Dialog
+
+**Issue:** #121
+**Phase:** Phase 1 — MVP
+**Type:** Frontend-only feature
+
+## Summary
+
+Add a confirmation dialog when canceling an event to prevent accidental deletion. This also establishes the first reusable shared UI component (`ConfirmationDialogComponent`) under `shared/components/`.
+
+**Scope:** Frontend-only. Backend cancel command, handler, domain event, and GraphQL mutation are already implemented.
+
+## Tasks
+
+1. Spec documentation
+2. Create reusable `ConfirmationDialogComponent` in `shared/components/`
+3. Integrate confirmation dialog into `event-dialog.component.ts`
+4. Write unit tests for both components
+5. Verify all tests pass

--- a/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/references.md
+++ b/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/references.md
@@ -1,0 +1,18 @@
+# Event Cancel Confirmation Dialog — References
+
+## Source Files
+
+- `src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.ts` — Existing event dialog to modify
+- `src/frontend/family-hub-web/src/app/features/calendar/services/calendar.service.ts` — `cancelCalendarEvent()` method
+- `src/frontend/family-hub-web/src/app/features/calendar/components/calendar-page/calendar-page.component.ts` — Parent component handling `eventCancelled`
+
+## New Files
+
+- `src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts`
+- `src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.spec.ts`
+- `src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.spec.ts`
+
+## Documentation
+
+- [Frontend Development Guide](docs/guides/FRONTEND_DEVELOPMENT.md)
+- [Issue #121](https://github.com/andrekirst/family2/issues/121)

--- a/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/shape.md
+++ b/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/shape.md
@@ -1,0 +1,35 @@
+# Event Cancel Confirmation Dialog — Shape
+
+## Components
+
+### ConfirmationDialogComponent (NEW)
+
+- **Path:** `src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts`
+- **Type:** Standalone Angular component, inline template with Tailwind CSS
+- **Inputs:** `title`, `message`, `confirmLabel`, `cancelLabel`, `variant`, `isLoading`
+- **Outputs:** `confirmed`, `cancelled`
+- **Behavior:** Modal overlay with dismiss via overlay click, close button, Escape key
+
+### EventDialogComponent (MODIFIED)
+
+- **Path:** `src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.ts`
+- **Changes:** Add `showCancelConfirmation` signal, refactor `onCancel()` → show dialog, add `onCancelConfirmed()` and `onCancelDismissed()`
+
+## Data Flow
+
+```
+User clicks "Cancel Event"
+  → showCancelConfirmation.set(true)
+  → ConfirmationDialogComponent appears with event name
+  → User clicks "Cancel Event" (confirm)
+    → calendarService.cancelCalendarEvent(id)
+    → eventCancelled.emit()
+  → User clicks "Go Back" / overlay / Escape
+    → showCancelConfirmation.set(false)
+```
+
+## Accessibility
+
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+- Escape key dismisses
+- `data-testid` attributes for E2E testing

--- a/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/standards.md
+++ b/agent-os/specs/2026-02-11-event-cancel-confirmation-dialog/standards.md
@@ -1,0 +1,12 @@
+# Event Cancel Confirmation Dialog — Standards
+
+## Patterns Applied
+
+- **Standalone component** with `standalone: true` (no NgModules)
+- **Angular Signals** for reactive state (`signal()`)
+- **inject()** for dependency injection
+- **Inline template** with Tailwind CSS utility classes
+- **Modal overlay pattern:** `fixed inset-0 bg-black/50 z-50` with `$event.stopPropagation()`
+- **data-testid** attributes on all interactive elements
+- **Accessibility:** `role="dialog"`, `aria-modal="true"`, keyboard support
+- **Service call pattern:** `isLoading` → subscribe → success/error handling

--- a/src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.spec.ts
+++ b/src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.spec.ts
@@ -1,0 +1,162 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { EventDialogComponent } from './event-dialog.component';
+import { CalendarService, CalendarEventDto } from '../../services/calendar.service';
+import { UserService } from '../../../../core/user/user.service';
+import { InvitationService } from '../../../family/services/invitation.service';
+
+const mockEvent: CalendarEventDto = {
+  id: 'event-1',
+  familyId: 'family-1',
+  createdBy: 'user-1',
+  title: 'Doctor Appointment',
+  description: 'Annual checkup',
+  location: 'Hospital',
+  startTime: '2026-03-01T09:00:00Z',
+  endTime: '2026-03-01T10:00:00Z',
+  isAllDay: false,
+  type: 'Medical',
+  isCancelled: false,
+  createdAt: '2026-02-01T00:00:00Z',
+  updatedAt: '2026-02-01T00:00:00Z',
+  attendees: [{ userId: 'user-1' }],
+};
+
+describe('EventDialogComponent — Cancel Confirmation', () => {
+  let component: EventDialogComponent;
+  let fixture: ComponentFixture<EventDialogComponent>;
+  let nativeElement: HTMLElement;
+  let calendarService: { cancelCalendarEvent: ReturnType<typeof vi.fn> };
+  let invitationService: { getFamilyMembers: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    calendarService = {
+      cancelCalendarEvent: vi.fn(),
+    };
+    invitationService = {
+      getFamilyMembers: vi.fn().mockReturnValue(of([])),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [EventDialogComponent],
+      providers: [
+        { provide: CalendarService, useValue: calendarService },
+        { provide: UserService, useValue: { currentUser: () => null } },
+        { provide: InvitationService, useValue: invitationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EventDialogComponent);
+    component = fixture.componentInstance;
+    component.event = mockEvent;
+    fixture.detectChanges();
+    nativeElement = fixture.nativeElement;
+  });
+
+  it('should not show confirmation dialog initially', () => {
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeNull();
+  });
+
+  it('should show confirmation dialog when Cancel Event button is clicked', () => {
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeTruthy();
+  });
+
+  it('should display event title in confirmation message', () => {
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    const message = queryByTestId('confirmation-dialog-message')?.textContent?.trim();
+    expect(message).toContain('Doctor Appointment');
+    expect(message).toContain('cannot be undone');
+  });
+
+  it('should call calendarService.cancelCalendarEvent on confirm', () => {
+    calendarService.cancelCalendarEvent.mockReturnValue(of(true));
+
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+    fixture.detectChanges();
+
+    expect(calendarService.cancelCalendarEvent).toHaveBeenCalledWith('event-1');
+  });
+
+  it('should emit eventCancelled on successful cancel', () => {
+    calendarService.cancelCalendarEvent.mockReturnValue(of(true));
+    const spy = vi.fn();
+    component.eventCancelled.subscribe(spy);
+
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hide confirmation dialog on dismiss (Go Back)', () => {
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeTruthy();
+
+    queryByTestId('confirmation-dialog-cancel')?.click();
+    fixture.detectChanges();
+
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeNull();
+  });
+
+  it('should set error message on cancel failure', () => {
+    calendarService.cancelCalendarEvent.mockReturnValue(of(false));
+
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+    fixture.detectChanges();
+
+    expect(queryByTestId('event-error')?.textContent?.trim()).toBe('Failed to cancel event');
+  });
+
+  it('should set error message on cancel error', () => {
+    calendarService.cancelCalendarEvent.mockReturnValue(throwError(() => new Error('Network')));
+
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+    fixture.detectChanges();
+
+    expect(queryByTestId('event-error')?.textContent?.trim()).toBe('An error occurred');
+  });
+
+  it('should hide confirmation dialog after cancel error', () => {
+    calendarService.cancelCalendarEvent.mockReturnValue(throwError(() => new Error('Network')));
+
+    queryByTestId('cancel-event-button')?.click();
+    fixture.detectChanges();
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+    fixture.detectChanges();
+
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeNull();
+  });
+
+  it('should not show Cancel Event button in create mode', async () => {
+    const createFixture = TestBed.createComponent(EventDialogComponent);
+    createFixture.componentInstance.selectedDate = new Date(2026, 2, 1);
+    createFixture.detectChanges();
+
+    expect(
+      createFixture.nativeElement.querySelector('[data-testid="cancel-event-button"]'),
+    ).toBeNull();
+  });
+
+  function queryByTestId(testId: string): HTMLElement | null {
+    return nativeElement.querySelector(`[data-testid="${testId}"]`);
+  }
+});

--- a/src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.ts
+++ b/src/frontend/family-hub-web/src/app/features/calendar/components/event-dialog/event-dialog.component.ts
@@ -1,16 +1,26 @@
-import { Component, EventEmitter, Input, Output, signal, inject, OnInit } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  signal,
+  computed,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CalendarService, CalendarEventDto } from '../../services/calendar.service';
 import { UserService, CurrentUser } from '../../../../core/user/user.service';
 import { InvitationService } from '../../../family/services/invitation.service';
+import { ConfirmationDialogComponent } from '../../../../shared/components/confirmation-dialog/confirmation-dialog.component';
 
 const EVENT_TYPES = ['Personal', 'Medical', 'School', 'Work', 'Social', 'Travel', 'Other'];
 
 @Component({
   selector: 'app-event-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ConfirmationDialogComponent],
   template: `
     <div
       class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
@@ -225,6 +235,21 @@ const EVENT_TYPES = ['Personal', 'Medical', 'School', 'Work', 'Social', 'Travel'
         </div>
       </div>
     </div>
+
+    @if (showCancelConfirmation()) {
+      <app-confirmation-dialog
+        title="Cancel Event"
+        [message]="cancelConfirmationMessage()"
+        confirmLabel="Cancel Event"
+        cancelLabel="Go Back"
+        variant="danger"
+        icon="trash"
+        [isLoading]="isCancelLoading()"
+        (confirmed)="onCancelConfirmed()"
+        (cancelled)="onCancelDismissed()"
+        data-testid="cancel-event-confirmation"
+      />
+    }
   `,
 })
 export class EventDialogComponent implements OnInit {
@@ -254,6 +279,11 @@ export class EventDialogComponent implements OnInit {
   errorMessage = signal<string | null>(null);
   familyMembers = signal<CurrentUser[]>([]);
   isEditMode = signal(false);
+  showCancelConfirmation = signal(false);
+  isCancelLoading = signal(false);
+  cancelConfirmationMessage = computed(
+    () => `Are you sure you want to cancel '${this.title()}'? This action cannot be undone.`,
+  );
 
   ngOnInit(): void {
     if (this.event) {
@@ -388,11 +418,17 @@ export class EventDialogComponent implements OnInit {
 
   onCancel(): void {
     if (!this.event) return;
+    this.showCancelConfirmation.set(true);
+  }
 
-    this.isLoading.set(true);
+  onCancelConfirmed(): void {
+    if (!this.event) return;
+
+    this.isCancelLoading.set(true);
     this.calendarService.cancelCalendarEvent(this.event.id).subscribe({
       next: (success) => {
-        this.isLoading.set(false);
+        this.isCancelLoading.set(false);
+        this.showCancelConfirmation.set(false);
         if (success) {
           this.eventCancelled.emit();
         } else {
@@ -400,10 +436,15 @@ export class EventDialogComponent implements OnInit {
         }
       },
       error: () => {
-        this.isLoading.set(false);
+        this.isCancelLoading.set(false);
+        this.showCancelConfirmation.set(false);
         this.errorMessage.set('An error occurred');
       },
     });
+  }
+
+  onCancelDismissed(): void {
+    this.showCancelConfirmation.set(false);
   }
 
   onDismiss(): void {

--- a/src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.spec.ts
+++ b/src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.spec.ts
@@ -1,0 +1,211 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConfirmationDialogComponent } from './confirmation-dialog.component';
+
+describe('ConfirmationDialogComponent', () => {
+  let component: ConfirmationDialogComponent;
+  let fixture: ComponentFixture<ConfirmationDialogComponent>;
+  let nativeElement: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfirmationDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmationDialogComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.nativeElement;
+  });
+
+  function render(): void {
+    fixture.detectChanges();
+  }
+
+  it('should create', () => {
+    render();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render with default props', () => {
+    render();
+    expect(queryByTestId('confirmation-dialog-title')?.textContent?.trim()).toBe('Confirm');
+    expect(queryByTestId('confirmation-dialog-message')?.textContent?.trim()).toBe('Are you sure?');
+    expect(queryByTestId('confirmation-dialog-confirm')?.textContent?.trim()).toBe('Confirm');
+    expect(queryByTestId('confirmation-dialog-cancel')?.textContent?.trim()).toBe('Cancel');
+  });
+
+  it('should render with custom props', () => {
+    component.title = 'Delete Item';
+    component.message = 'This will permanently delete the item.';
+    component.confirmLabel = 'Delete';
+    component.cancelLabel = 'Keep';
+    render();
+
+    expect(queryByTestId('confirmation-dialog-title')?.textContent?.trim()).toBe('Delete Item');
+    expect(queryByTestId('confirmation-dialog-message')?.textContent?.trim()).toBe(
+      'This will permanently delete the item.',
+    );
+    expect(queryByTestId('confirmation-dialog-confirm')?.textContent?.trim()).toBe('Delete');
+    expect(queryByTestId('confirmation-dialog-cancel')?.textContent?.trim()).toBe('Keep');
+  });
+
+  it('should emit confirmed on confirm button click', () => {
+    render();
+    const spy = vi.fn();
+    component.confirmed.subscribe(spy);
+
+    queryByTestId('confirmation-dialog-confirm')?.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit cancelled on cancel button click', () => {
+    render();
+    const spy = vi.fn();
+    component.cancelled.subscribe(spy);
+
+    queryByTestId('confirmation-dialog-cancel')?.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit cancelled on overlay click', () => {
+    render();
+    const spy = vi.fn();
+    component.cancelled.subscribe(spy);
+
+    queryByTestId('confirmation-dialog-overlay')?.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit cancelled on dialog body click (stopPropagation)', () => {
+    render();
+    const spy = vi.fn();
+    component.cancelled.subscribe(spy);
+
+    queryByTestId('confirmation-dialog')?.click();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should emit cancelled on Escape key', () => {
+    render();
+    const spy = vi.fn();
+    component.cancelled.subscribe(spy);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit cancelled on Escape key when loading', () => {
+    component.isLoading = true;
+    render();
+
+    const spy = vi.fn();
+    component.cancelled.subscribe(spy);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should show "Processing..." when loading', () => {
+    component.isLoading = true;
+    render();
+
+    expect(queryByTestId('confirmation-dialog-confirm')?.textContent?.trim()).toBe('Processing...');
+  });
+
+  it('should disable buttons when loading', () => {
+    component.isLoading = true;
+    render();
+
+    expect(queryByTestId('confirmation-dialog-confirm')?.getAttribute('disabled')).not.toBeNull();
+    expect(queryByTestId('confirmation-dialog-cancel')?.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should apply danger variant styles to confirm button', () => {
+    component.variant = 'danger';
+    render();
+
+    const button = queryByTestId('confirmation-dialog-confirm');
+    expect(button?.classList.contains('bg-red-500')).toBe(true);
+  });
+
+  it('should apply warning variant styles to confirm button', () => {
+    component.variant = 'warning';
+    render();
+
+    const button = queryByTestId('confirmation-dialog-confirm');
+    expect(button?.classList.contains('bg-amber-500')).toBe(true);
+  });
+
+  it('should apply info variant styles to confirm button', () => {
+    render();
+
+    const button = queryByTestId('confirmation-dialog-confirm');
+    expect(button?.classList.contains('bg-blue-500')).toBe(true);
+  });
+
+  it('should have correct accessibility attributes', () => {
+    render();
+    const overlay = queryByTestId('confirmation-dialog-overlay');
+    expect(overlay?.getAttribute('role')).toBe('dialog');
+    expect(overlay?.getAttribute('aria-modal')).toBe('true');
+    expect(overlay?.getAttribute('aria-labelledby')).toBe('confirmation-dialog-title');
+  });
+
+  it('should have all required data-testid attributes', () => {
+    render();
+    expect(queryByTestId('confirmation-dialog-overlay')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog-title')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog-message')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog-confirm')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog-cancel')).toBeTruthy();
+    expect(queryByTestId('confirmation-dialog-icon')).toBeTruthy();
+  });
+
+  it('should render icon with correct variant styling', () => {
+    component.variant = 'danger';
+    render();
+
+    const iconContainer = queryByTestId('confirmation-dialog-icon');
+    expect(iconContainer?.classList.contains('bg-red-50')).toBe(true);
+    expect(iconContainer?.classList.contains('text-red-500')).toBe(true);
+  });
+
+  it('should render warning icon with correct variant styling', () => {
+    component.variant = 'warning';
+    render();
+
+    const iconContainer = queryByTestId('confirmation-dialog-icon');
+    expect(iconContainer?.classList.contains('bg-amber-50')).toBe(true);
+    expect(iconContainer?.classList.contains('text-amber-500')).toBe(true);
+  });
+
+  it('should render info icon with correct variant styling', () => {
+    render();
+
+    const iconContainer = queryByTestId('confirmation-dialog-icon');
+    expect(iconContainer?.classList.contains('bg-blue-50')).toBe(true);
+    expect(iconContainer?.classList.contains('text-blue-500')).toBe(true);
+  });
+
+  it('should render trash icon when icon input is trash', () => {
+    component.icon = 'trash';
+    render();
+
+    const iconContainer = queryByTestId('confirmation-dialog-icon');
+    const svg = iconContainer?.querySelector('svg');
+    expect(svg).toBeTruthy();
+    // Trash icon has a distinctive path with "M14.74"
+    const path = svg?.querySelector('path');
+    expect(path?.getAttribute('d')).toContain('M14.74');
+  });
+
+  function queryByTestId(testId: string): HTMLElement | null {
+    return nativeElement.querySelector(`[data-testid="${testId}"]`);
+  }
+});

--- a/src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/frontend/family-hub-web/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,0 +1,161 @@
+import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-confirmation-dialog',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      (click)="onDismiss()"
+      role="dialog"
+      aria-modal="true"
+      [attr.aria-labelledby]="'confirmation-dialog-title'"
+      data-testid="confirmation-dialog-overlay"
+    >
+      <div
+        class="bg-white rounded-2xl max-w-md w-[90%] shadow-xl p-8"
+        (click)="$event.stopPropagation()"
+        data-testid="confirmation-dialog"
+      >
+        <!-- Icon + Text -->
+        <div class="flex items-start gap-4">
+          <div
+            [ngClass]="iconContainerClasses"
+            class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+            data-testid="confirmation-dialog-icon"
+          >
+            @switch (icon) {
+              @case ('trash') {
+                <svg
+                  class="w-6 h-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  />
+                </svg>
+              }
+              @case ('warning') {
+                <svg
+                  class="w-6 h-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                  />
+                </svg>
+              }
+              @default {
+                <svg
+                  class="w-6 h-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                  />
+                </svg>
+              }
+            }
+          </div>
+          <div>
+            <h2
+              id="confirmation-dialog-title"
+              class="text-base font-semibold text-gray-900"
+              data-testid="confirmation-dialog-title"
+            >
+              {{ title }}
+            </h2>
+            <p class="text-sm text-gray-500 mt-1" data-testid="confirmation-dialog-message">
+              {{ message }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Buttons -->
+        <div class="flex items-center justify-end gap-3 mt-6">
+          <button
+            type="button"
+            (click)="onDismiss()"
+            [disabled]="isLoading"
+            class="font-semibold text-sm text-gray-900 hover:text-gray-600 px-4 py-2.5 disabled:opacity-50"
+            data-testid="confirmation-dialog-cancel"
+          >
+            {{ cancelLabel }}
+          </button>
+          <button
+            type="button"
+            (click)="onConfirm()"
+            [disabled]="isLoading"
+            [ngClass]="confirmButtonClasses"
+            class="rounded-lg px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+            data-testid="confirmation-dialog-confirm"
+          >
+            {{ isLoading ? 'Processing...' : confirmLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class ConfirmationDialogComponent {
+  @Input() title = 'Confirm';
+  @Input() message = 'Are you sure?';
+  @Input() confirmLabel = 'Confirm';
+  @Input() cancelLabel = 'Cancel';
+  @Input() variant: 'danger' | 'warning' | 'info' = 'info';
+  @Input() icon: 'trash' | 'warning' | 'info' = 'info';
+  @Input() isLoading = false;
+
+  @Output() confirmed = new EventEmitter<void>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  @HostListener('document:keydown.escape')
+  onEscapeKey(): void {
+    if (!this.isLoading) {
+      this.onDismiss();
+    }
+  }
+
+  get confirmButtonClasses(): Record<string, boolean> {
+    return {
+      'bg-red-500 hover:bg-red-600': this.variant === 'danger',
+      'bg-amber-500 hover:bg-amber-600': this.variant === 'warning',
+      'bg-blue-500 hover:bg-blue-600': this.variant === 'info',
+    };
+  }
+
+  get iconContainerClasses(): Record<string, boolean> {
+    return {
+      'bg-red-50 text-red-500': this.variant === 'danger',
+      'bg-amber-50 text-amber-500': this.variant === 'warning',
+      'bg-blue-50 text-blue-500': this.variant === 'info',
+    };
+  }
+
+  onConfirm(): void {
+    this.confirmed.emit();
+  }
+
+  onDismiss(): void {
+    if (!this.isLoading) {
+      this.cancelled.emit();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add reusable `ConfirmationDialogComponent` with modern Dribbble-inspired design: icon-left/text-right layout, variant-colored icons (`danger`/`warning`/`info`), extra-rounded card, text-only cancel button, and solid confirm button
- Integrate confirmation dialog into `EventDialogComponent` for the cancel-event flow with loading state and error handling
- Add 20 unit tests for the confirmation dialog and 10 tests for the event-dialog cancel flow

## Test plan

- [x] All 20 `ConfirmationDialogComponent` tests pass (`ng test --no-watch`)
- [x] All 10 `EventDialogComponent` cancel confirmation tests pass
- [x] Visual check: open browser at localhost:4200, navigate to calendar, open an event, click "Cancel Event" — confirm the dialog matches the Dribbble reference design

🤖 Generated with [Claude Code](https://claude.com/claude-code)