### PR TITLE
feat(search): universal search command palette (#208)

### DIFF
--- a/docs/search-command-palette-notebooklm.md
+++ b/docs/search-command-palette-notebooklm.md
@@ -1,0 +1,432 @@
+# Issue #208: Universal Search & Command Palette — Complete Implementation Guide
+
+## Executive Summary
+
+The Universal Search & Command Palette is a feature for the Family Hub application that gives users a single keyboard shortcut (Ctrl+K) to search across all modules, execute commands, navigate the app, and use natural language phrases. It combines three data sources: client-side NLP parsing, server-side GraphQL search across 8 modules, and static default items with daily-rotating hints. The implementation spans the full stack from PostgreSQL queries through .NET 9 GraphQL to an Angular 19 modal component.
+
+---
+
+## 1. The Big Picture — What This Feature Does
+
+When a user presses Ctrl+K anywhere in the Family Hub app, a modal overlay appears with a search input. The palette serves four purposes:
+
+1. **Discovery** — When the input is empty, it shows 8 default items: 2 NLP hints (rotated daily), 2 quick actions, and 4 navigation shortcuts. This teaches users what they can do.
+
+2. **Natural Language Understanding** — The frontend parses what the user types using regex patterns. Typing "tomorrow event at 3 PM" creates a calendar event suggestion with the date and time pre-filled. This works entirely client-side with no server call.
+
+3. **Full-Text Search** — The query is also sent to the backend via GraphQL, where 8 module-specific search providers query PostgreSQL for matching family members, calendar events, files, messages, photos, automations, and dashboards.
+
+4. **Command Discovery** — The backend also returns matching commands from a registry of 22 actions (like "Invite Member", "Create Folder", "Upload Photo"), filtered by the user's permissions.
+
+All results are merged into a unified list with section headers, emoji icons, keyboard navigation, and instant routing when an item is selected.
+
+---
+
+## 2. Architecture Layers
+
+The system has five distinct layers:
+
+### Layer 1: User Interface (Angular Component)
+
+The `CommandPaletteComponent` is a standalone Angular 19 component placed at the root layout level. It renders a fixed-position modal with backdrop blur, search input, results list, and keyboard hint footer. It uses Angular signals for reactive state management.
+
+### Layer 2: Orchestration Service (Angular Service)
+
+The `CommandPaletteService` manages all state (open/closed, query, items, loading, error) and coordinates the three data sources. It handles debouncing (300ms), default item generation, and the special hint-click behavior.
+
+### Layer 3: Client-Side Intelligence (NLP Parser)
+
+The `NlpParserService` runs 17 regex patterns against the user's query, supporting both English and German. It includes date parsing ("tomorrow", "friday", "morgen") and time parsing ("3 PM", "15 Uhr"). This layer is completely independent of the server.
+
+### Layer 4: GraphQL API (Hot Chocolate)
+
+The `QueryType` resolver handles authentication, extracts the user's family membership and permissions from JWT claims, and dispatches a `UniversalSearchQuery` through the Mediator pipeline.
+
+### Layer 5: Data Collection (Search Providers + Command Registry)
+
+Eight `ISearchProvider` implementations query PostgreSQL through Entity Framework Core. A `CommandPaletteRegistry` singleton caches 22 commands from 8 `ICommandPaletteProvider` implementations, populated at application startup by an `IHostedService`.
+
+---
+
+## 3. Data Flow — Step by Step
+
+### Step 1: Opening the Palette
+
+The user presses Ctrl+K. The component captures this via a `@HostListener('document:keydown')`. The service sets `isOpen = true`, resets the query, and populates items with `getDefaultItems()`. The input is auto-focused via an Angular `effect()`.
+
+### Step 2: Default Items (Empty Query)
+
+When the query is empty, 8 static items are shown immediately with no network request:
+
+- **2 NLP Hints** (type: `hint`): Selected from a pool of 10 per locale using deterministic daily rotation. The algorithm uses `Math.floor(Date.now() / 86_400_000) % poolSize` — epoch-day modular arithmetic. Two consecutive indices are used so users see two different hints each day. The pool includes phrases like "tomorrow event at 3 PM", "invite john@example.com", "open calendar".
+
+- **2 Quick Actions** (type: `command`): "Create Event" routing to `/family/calendar?action=create` and "Send Message" routing to `/messages?action=create`.
+
+- **4 Navigation Items** (type: `navigation`): Dashboard, Calendar, Messages, Files — each with a specific route and module-specific emoji icon.
+
+### Step 3: User Types a Query
+
+As the user types, `onQueryChange()` is called. After 300ms of inactivity (debounce), `performSearch()` is triggered. Two things happen in parallel:
+
+**Client-side NLP parsing:** The `NlpParserService` tries each regex pattern against the query. If a pattern matches and the confidence exceeds 0.5, it returns an `NlpMatch` with a pre-built route. For example, "tomorrow event at 3 PM" would match the calendar event pattern, parse "tomorrow" to a date and "3 PM" to 15:00, and produce the route `/family/calendar?action=create&date=2026-03-06&time=15:00` with 0.9 confidence.
+
+**Server-side GraphQL search:** The `SearchService` sends an Apollo query to the `search.universal` endpoint. The request includes the query string, optional module filter, result limit, and the user's locale.
+
+### Step 4: Backend Processing
+
+The GraphQL `QueryType` resolver:
+
+1. Extracts the user ID from the JWT `sub` claim
+2. Looks up the user and resolves their family membership
+3. Extracts permissions from their family role (Owner > Admin > Member hierarchy)
+4. Dispatches `UniversalSearchQuery` with all resolved context
+
+The `UniversalSearchQueryHandler`:
+
+1. Filters search providers by requested modules (if specified)
+2. Builds a `SearchContext` with userId, familyId, query, limit, and locale
+3. Executes each provider sequentially (they share a scoped DbContext)
+4. Catches errors per provider — if one fails, the others continue
+5. Flattens all results and caps at 30 total
+6. Filters commands by keyword match and permission check
+7. Resolves German labels if locale is "de"
+
+### Step 5: Results Assembly
+
+Back in the frontend, the service assembles the final `PaletteItem[]` array in this order:
+
+1. NLP suggestions (type: `nlp`, max 1 item)
+2. Search results from GraphQL (type: `result`, up to 30 items)
+3. Commands from GraphQL (type: `command`, filtered subset of 22)
+
+### Step 6: Rendering
+
+The component renders items grouped by consecutive type values. Each group gets a section header:
+
+- `hint` → "Try saying..."
+- `nlp` → "Suggestions"
+- `result` → "Search Results"
+- `command` → "Commands"
+- `navigation` → "Navigation"
+
+Each item shows an emoji icon (type-specific or module-specific), title, optional description, optional module badge, and an "Enter" hint on the selected item.
+
+### Step 7: Item Execution
+
+When the user clicks or presses Enter on an item:
+
+- **Hint items:** Instead of navigating, the hint text fills the search input and triggers a search. This teaches users how NLP works by demonstrating it live.
+- **All other items:** The palette closes and `router.navigateByUrl(item.route)` navigates to the target.
+
+---
+
+## 4. Search Providers — What Each Module Searches
+
+### Family Module (FamilySearchProvider)
+
+Searches the family name, family members by name or email, and pending invitations. Requires a family context (returns empty if user has no family). Provides 3 commands: View Family, Invite Member (requires `family:invite` permission), Family Settings.
+
+### Calendar Module (CalendarSearchProvider)
+
+Searches calendar events within a 9-month window: 3 months in the past and 6 months in the future. Sorts results with upcoming events first. Provides 2 commands: Create Event, View Calendar.
+
+### File Management Module (FileManagementSearchProvider)
+
+The most comprehensive provider. Searches files (by name), folders (by name), albums (by name), tags (by name), secure notes (category only — content is encrypted), and share links. Provides 8 commands covering Create Folder, Upload File, Create Album, Browse Files, View Albums, Manage Tags, Create Secure Note, View Secure Notes.
+
+### Messaging Module (MessagingSearchProvider)
+
+Searches messages by content, ordered newest first. Provides 2 commands: New Message, View Messages.
+
+### Dashboard Module (DashboardSearchProvider)
+
+Searches personal and family dashboards. Provides 1 command: Open Dashboard.
+
+### Event Chain Module (EventChainSearchProvider)
+
+Searches automation workflows by name and description, includes enabled/disabled status in results. Provides 2 commands: Create Chain, View Chains.
+
+### Photos Module (PhotosSearchProvider)
+
+Searches photos by filename and caption, ordered by creation date (newest first). Provides 2 commands: Upload Photo, View Photos.
+
+### Auth Module (No SearchProvider)
+
+Does not contribute search results, but provides 2 commands via `ProfileCommandPaletteProvider`: View Profile, Settings.
+
+---
+
+## 5. NLP Rules — Natural Language Understanding
+
+The NLP system uses 17 regex patterns per locale (English and German). Patterns are tried in order; the best match (highest confidence above 0.5) wins.
+
+### Calendar Event Creation (Confidence: 0.65–0.9)
+
+- English: "tomorrow event at 3 PM", "event friday at 10 AM", "meeting today"
+- German: "morgen Termin um 15 Uhr", "Termin Freitag um 10 Uhr"
+- Parses relative dates: today, tomorrow, day names (finds next occurrence)
+- Parses times: 12-hour ("3 PM") and 24-hour ("15 Uhr") formats
+- Route includes pre-filled date and time query parameters
+
+### Navigation (Confidence: 0.85)
+
+- English: "go to dashboard", "open calendar", "show messages", "view files"
+- German: "zum Dashboard gehen", "Kalender öffnen", "Nachrichten zeigen"
+- Covers 10 destinations: Dashboard, Calendar, Messages, Files, Photos, Albums, Family, Automations, Profile, Settings
+
+### Actions (Confidence: 0.7–0.9)
+
+- Invite with email: "invite john@example.com" → pre-fills email
+- Invite generic: "invite member" → opens invite dialog
+- Create folder: "create folder Vacation" → pre-fills name
+- Create album: "create album Summer" → pre-fills name
+- Send message: "send a message" → opens compose
+- Search files: "find files report" → file search with query
+- Upload: "upload a file" → opens upload dialog
+
+### Date Parsing
+
+Supports relative dates in both languages:
+
+- "today"/"heute" → current date
+- "tomorrow"/"morgen" → next day
+- "übermorgen" (German only) → day after tomorrow
+- Day names in both languages → next occurrence of that weekday
+
+### Time Parsing
+
+- English: "3 PM" → "15:00", "10:30 AM" → "10:30"
+- German: "15 Uhr" → "15:00", "10:30 Uhr" → "10:30"
+
+---
+
+## 6. Command Palette Registry — Startup Architecture
+
+At application startup, the system uses an `IHostedService` called `CommandPaletteRegistryInitializer` to populate the command registry:
+
+1. `Program.cs` registers all feature modules via `RegisterModule<T>()`
+2. Each module registers its `ICommandPaletteProvider` as a singleton and its `ISearchProvider` as scoped
+3. The `SearchModule` registers the `CommandPaletteRegistry` as a singleton
+4. At startup, `CommandPaletteRegistryInitializer` iterates all `ICommandPaletteProvider` instances via dependency injection and calls `registry.RegisterProvider(provider)` for each
+5. This populates the registry with all 22 commands from 8 modules
+6. The registry is then available as a singleton for the lifetime of the application
+
+This pattern means commands are cached once at startup with zero runtime overhead. Search providers, by contrast, are scoped per-request because they need database access.
+
+---
+
+## 7. Internationalization (i18n) Strategy
+
+The system supports English and German at every layer:
+
+### Frontend
+
+- `LOCALE_ID` injection determines which NLP rules and hint pool to use
+- Separate rule files: `en.rules.ts` and `de.rules.ts` with equivalent patterns
+- Date parser handles "tomorrow"/"morgen", day names in both languages
+- Time parser handles "3 PM" (12-hour) and "15 Uhr" (24-hour)
+- Hint pool: 10 English phrases, 10 German phrases
+
+### Backend
+
+- `CommandDescriptor` has optional `LabelDe` and `DescriptionDe` fields
+- Keywords arrays include both English and German terms (e.g., `["invite", "einladen", "member", "mitglied"]`)
+- `UniversalSearchQuery` carries a `Locale` parameter
+- `UniversalSearchQueryHandler.ResolveGermanLabels()` swaps in German labels when locale starts with "de"
+- Search providers check locale for description text
+
+---
+
+## 8. Error Resilience Design
+
+The system is designed to degrade gracefully at every level:
+
+- **NLP Parser failure:** Caught in a try/catch. If NLP parsing throws, the GraphQL search still runs and results are shown without NLP suggestions.
+
+- **Individual search provider failure:** Each provider's `SearchAsync()` call is wrapped in try/catch in the query handler. If the Calendar provider throws, the other 7 providers still return their results. The error is logged with the provider name and query.
+
+- **GraphQL request failure:** The `SearchService` returns an empty result `{results: [], commands: []}`. The palette shows a "Search failed" error message.
+
+- **Authentication failure:** The GraphQL query is decorated with `[Authorize]`. Unauthenticated requests receive a standard GraphQL auth error.
+
+---
+
+## 9. UI Component Design
+
+### Modal Structure
+
+- Fixed position overlay at z-index 50
+- Semi-transparent backdrop with blur effect
+- Centered modal at 15% from top, max-width 36rem
+- Rounded corners, shadow, white background
+
+### Search Input Area
+
+- Search magnifying glass icon
+- Text input with placeholder "Search or type a command..."
+- Loading indicator (3 animated dots) during GraphQL requests
+- Escape key hint badge
+
+### Results List
+
+- Scrollable area with max height 320px
+- Items grouped by type with uppercase section headers
+- Each item: 32x32 icon area, title (truncated), optional description, optional module badge
+- Selected item: blue highlight, "Enter" keyboard hint
+- Hover changes selection
+
+### Footer
+
+- Only visible when items are present
+- Keyboard hints: ↑↓ navigate, Enter select, Esc close
+
+### Accessibility
+
+- `role="dialog"` with `aria-modal="true"` and `aria-label`
+- `role="listbox"` on results with `aria-activedescendant`
+- `role="option"` on each item with `aria-selected`
+- Focus management: saves previous element, auto-focuses input, restores on close
+- Tab trapping prevents focus from escaping the modal
+
+---
+
+## 10. Key Technical Decisions
+
+### Why Client-Side NLP?
+
+Natural language parsing runs on the client using regex patterns rather than sending text to a server-side NLP service. This provides instant feedback (no network latency), works offline, and keeps the implementation simple. The confidence scoring system (0-1 scale with 0.5 threshold) prevents false positives.
+
+### Why Sequential Provider Execution?
+
+Search providers execute sequentially rather than in parallel because they share a scoped Entity Framework DbContext. Parallel execution would require separate DbContext instances per provider, adding complexity. The sequential approach is fast enough because each provider's query is simple and indexed.
+
+### Why Singleton Command Registry?
+
+Commands are static metadata (label, description, route, permissions). They never change at runtime, so caching them once at startup eliminates repeated DI resolution and list construction on every request.
+
+### Why Daily Hint Rotation?
+
+Using epoch-day math for hint selection means all users see the same hints on the same day (predictable), hints change daily (fresh), and no storage or state management is needed. The algorithm is deterministic and requires zero configuration.
+
+### Why Separate Hint Click Behavior?
+
+When users click an NLP hint, instead of navigating directly, the hint text fills the search input and triggers NLP parsing. This teaches users the natural language syntax by demonstrating it live — a progressive disclosure pattern that reduces the learning curve.
+
+---
+
+## 11. Data Models Reference
+
+### PaletteItem (Frontend — Unified Display Model)
+
+```
+type: 'nlp' | 'result' | 'command' | 'hint' | 'navigation'
+title: string
+description?: string
+icon: string
+route: string
+module?: string
+confidence?: number
+```
+
+### SearchResultItem (Backend — Provider Output)
+
+```
+Title: string
+Description?: string
+Module: string (e.g., "family", "calendar")
+Icon: string (e.g., "users", "calendar")
+Route: string (e.g., "/family/members/abc-123")
+Metadata?: Dictionary<string, string>
+```
+
+### CommandDescriptor (Backend — Registry Entry)
+
+```
+Label: string (English)
+Description: string (English)
+Keywords: string[] (mixed language)
+Route: string
+RequiredPermissions: string[]
+Icon: string
+Group: string (module name)
+LabelDe?: string (German)
+DescriptionDe?: string (German)
+```
+
+### SearchContext (Backend — Provider Input)
+
+```
+UserId: UserId
+FamilyId?: FamilyId
+Query: string
+Limit: int (default 10)
+Locale?: string
+```
+
+### NlpMatch (Frontend — Parser Output)
+
+```
+type: 'create-event' | 'navigate' | 'invite-member' | 'create-folder' | 'create-album' | 'send-message' | 'search-files'
+confidence: number (0-1)
+title?: string
+date?: Date
+time?: string (HH:MM)
+route: string
+description: string
+```
+
+---
+
+## 12. File Structure
+
+### Backend Files
+
+- `src/FamilyHub.Api/Common/Search/` — Core interfaces and models (ISearchProvider, ICommandPaletteProvider, ICommandPaletteRegistry, CommandDescriptor, SearchContext, SearchResultItem, CommandPaletteRegistry, CommandPaletteRegistryInitializer)
+- `src/FamilyHub.Api/Features/Search/` — Search module, GraphQL query type, handler, request/result models
+- `src/FamilyHub.Api/Features/{Module}/Application/Search/` — Per-module search provider and command palette provider implementations
+- `tests/FamilyHub.Search.Tests/` — 12 unit tests for the query handler
+
+### Frontend Files
+
+- `src/app/core/nlp/` — NLP parser service, models, and locale-specific rules (en.rules.ts, de.rules.ts, date-parser.ts, time-parser.ts)
+- `src/app/shared/models/search.models.ts` — TypeScript interfaces for PaletteItem, SearchResultItem, CommandDescriptor
+- `src/app/shared/graphql/search.operations.ts` — GraphQL query definition
+- `src/app/shared/services/search.service.ts` — Apollo GraphQL client wrapper
+- `src/app/shared/services/command-palette.service.ts` — State management and orchestration
+- `src/app/shared/components/command-palette/command-palette.component.ts` — UI component with template
+- `src/app/shared/layout/layout.component.ts` — App shell that hosts the palette
+
+---
+
+## 13. Technology Stack Used
+
+- **Backend:** .NET 9, C# 13, Hot Chocolate (GraphQL), martinothamar/Mediator (CQRS), Entity Framework Core, PostgreSQL, Vogen (value objects)
+- **Frontend:** Angular 19, TypeScript, Angular Signals, Apollo Client (GraphQL), Tailwind CSS
+- **Auth:** Keycloak (OAuth 2.0 / OIDC), JWT claims
+- **Testing:** xUnit, FluentAssertions, NullLogger for test doubles
+
+---
+
+## 14. Performance Characteristics
+
+- **Default items:** Zero latency — computed locally from static data
+- **NLP parsing:** Sub-millisecond — 17 regex patterns tested against a short string
+- **GraphQL search:** Network-dependent — typically 50-200ms including 8 provider queries
+- **Debouncing:** 300ms delay prevents excessive API calls during typing
+- **Command registry:** Zero per-request cost — populated once at startup as singleton
+- **Result cap:** Maximum 30 search results prevents overwhelming the UI
+- **Focus management:** Uses `setTimeout(0)` for DOM-ready focus after Angular renders the input
+
+---
+
+## 15. Summary Diagram Description
+
+Imagine the system as three concentric rings:
+
+The **outer ring** is the Angular UI — the modal component that the user sees and interacts with. It captures keyboard input, renders items with section headers and emoji icons, and navigates when items are selected.
+
+The **middle ring** is the orchestration layer — the `CommandPaletteService` that decides which data source to use (defaults for empty queries, NLP + GraphQL for typed queries), manages debouncing and loading states, and normalizes everything into `PaletteItem[]`.
+
+The **inner ring** is the data layer — split between client-side NLP (regex patterns producing routes with pre-filled parameters) and server-side GraphQL (8 search providers querying PostgreSQL, plus a cached command registry filtered by permissions and locale).
+
+All three rings work together to provide a unified, keyboard-first search experience that works across the entire application, supports two languages, degrades gracefully on errors, and teaches users about NLP capabilities through interactive hints.

--- a/docs/search-command-palette-overview.html
+++ b/docs/search-command-palette-overview.html
@@ -1,0 +1,921 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Search Command Palette - Implementation Overview (#208)</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --surface2: #334155;
+    --border: #475569;
+    --text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --accent: #3b82f6;
+    --accent2: #8b5cf6;
+    --green: #22c55e;
+    --orange: #f97316;
+    --pink: #ec4899;
+    --cyan: #06b6d4;
+    --yellow: #eab308;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 2rem;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+  h1 { font-size: 2.2rem; margin-bottom: 0.5rem; }
+  h1 span { color: var(--accent); }
+  .subtitle { color: var(--text-muted); font-size: 1.1rem; margin-bottom: 2.5rem; }
+  h2 {
+    font-size: 1.4rem;
+    margin: 2.5rem 0 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--accent);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  h2 .num {
+    background: var(--accent);
+    color: white;
+    width: 28px; height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 0.85rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  h3 { font-size: 1.1rem; margin: 1.5rem 0 0.75rem; color: var(--cyan); }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin: 1rem 0;
+  }
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+  }
+  .card-small {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem;
+  }
+  .card-small h4 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .badge-blue { background: #1e40af; color: #93c5fd; }
+  .badge-green { background: #166534; color: #86efac; }
+  .badge-purple { background: #581c87; color: #d8b4fe; }
+  .badge-orange { background: #9a3412; color: #fdba74; }
+  .badge-pink { background: #831843; color: #f9a8d4; }
+  .badge-cyan { background: #164e63; color: #67e8f9; }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+  }
+  th {
+    background: var(--surface2);
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    font-weight: 600;
+    color: var(--cyan);
+    border-bottom: 2px solid var(--border);
+  }
+  td {
+    padding: 0.5rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  tr:hover td { color: var(--text); background: rgba(59,130,246,0.05); }
+  code {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.85em;
+    background: var(--surface2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--green);
+  }
+  pre {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    margin: 0.75rem 0;
+    color: var(--text-muted);
+  }
+  .mermaid {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin: 1rem 0;
+    text-align: center;
+  }
+  ul, ol { padding-left: 1.5rem; margin: 0.5rem 0; }
+  li { margin: 0.3rem 0; color: var(--text-muted); }
+  li strong { color: var(--text); }
+  .flow-arrow { color: var(--accent); font-weight: bold; font-size: 1.2rem; }
+  .highlight { color: var(--yellow); font-weight: 600; }
+  .toc { columns: 2; column-gap: 2rem; }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+  .layer-label {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-right: 6px;
+  }
+  .layer-fe { background: #1e3a5f; color: #7dd3fc; }
+  .layer-be { background: #3b1f5e; color: #d8b4fe; }
+  .layer-gql { background: #1e4038; color: #6ee7b7; }
+  .section-intro {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+    max-width: 900px;
+  }
+  .emoji { font-size: 1.3rem; }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+
+<h1><span>#208</span> Universal Search &amp; Command Palette</h1>
+<p class="subtitle">Complete implementation overview &mdash; how data is collected, transferred, and displayed</p>
+
+<!-- ================================================================ -->
+<h2><span class="num">1</span> Architecture Overview</h2>
+
+<p class="section-intro">
+  The command palette (<kbd>Ctrl+K</kbd>) combines three data sources into a unified interface:
+  <strong>client-side NLP parsing</strong>, <strong>server-side GraphQL search</strong>, and
+  <strong>static default items</strong>. Each source contributes items with a specific type that
+  determines grouping, icons, and click behavior.
+</p>
+
+<div class="mermaid">
+flowchart TB
+    subgraph USER["User Interaction"]
+        K["Ctrl+K / Click"]
+        TYPE["Types query"]
+        SELECT["Selects item"]
+    end
+
+    subgraph FE["Frontend (Angular 19)"]
+        CP["CommandPaletteComponent"]
+        CPS["CommandPaletteService"]
+        NLP["NlpParserService"]
+        SS["SearchService"]
+        DEF["Default Items<br/>(hints + nav + commands)"]
+    end
+
+    subgraph GQL["GraphQL Layer"]
+        QUERY["search.universal(input)"]
+    end
+
+    subgraph BE["Backend (.NET 9)"]
+        QH["UniversalSearchQueryHandler"]
+        SP["ISearchProvider[]<br/>(8 modules)"]
+        CR["ICommandPaletteRegistry<br/>(22 commands)"]
+    end
+
+    subgraph DB["Data Layer"]
+        PG["PostgreSQL"]
+    end
+
+    K --> CP
+    TYPE --> CP
+    CP -->|debounce 300ms| CPS
+
+    CPS -->|"empty query"| DEF
+    CPS -->|"has query"| NLP
+    CPS -->|"has query"| SS
+
+    NLP -->|"regex match"| CPS
+    SS -->|"Apollo query"| QUERY
+    QUERY --> QH
+
+    QH --> SP
+    QH --> CR
+    SP --> PG
+    CR -->|"singleton cache"| QH
+
+    QH -->|"UniversalSearchResult"| SS
+    SS --> CPS
+
+    DEF --> CP
+    CPS -->|"PaletteItem[]"| CP
+
+    SELECT --> CP
+    CP -->|"router.navigateByUrl()"| ROUTE["Angular Router"]
+
+    style USER fill:#1e293b,stroke:#3b82f6,color:#e2e8f0
+    style FE fill:#1e3a5f,stroke:#3b82f6,color:#e2e8f0
+    style GQL fill:#1e4038,stroke:#22c55e,color:#e2e8f0
+    style BE fill:#3b1f5e,stroke:#8b5cf6,color:#e2e8f0
+    style DB fill:#3b1f1f,stroke:#f97316,color:#e2e8f0
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">2</span> Data Collection &mdash; Three Sources</h2>
+
+<div class="card-grid">
+  <div class="card-small">
+    <h4><span class="emoji">&#x1F4A1;</span> Source 1: Default Items <span class="badge badge-cyan">Client-Side</span></h4>
+    <p style="color:var(--text-muted);font-size:0.9rem;margin-bottom:0.75rem;">
+      Shown immediately when the palette opens with an empty query. No network request needed.
+    </p>
+    <table>
+      <tr><th>Type</th><th>Count</th><th>Content</th></tr>
+      <tr><td><code>hint</code></td><td>2</td><td>Daily-rotating NLP example phrases (EN/DE pool of 10)</td></tr>
+      <tr><td><code>command</code></td><td>2</td><td>Create Event, Send Message</td></tr>
+      <tr><td><code>navigation</code></td><td>4</td><td>Dashboard, Calendar, Messages, Files</td></tr>
+    </table>
+    <pre>getDailyIndex(poolSize, offset) {
+  const day = Math.floor(Date.now() / 86_400_000);
+  return (day + offset) % poolSize;
+}</pre>
+  </div>
+
+  <div class="card-small">
+    <h4><span class="emoji">&#x2728;</span> Source 2: NLP Parser <span class="badge badge-green">Client-Side</span></h4>
+    <p style="color:var(--text-muted);font-size:0.9rem;margin-bottom:0.75rem;">
+      Regex-based pattern matching against locale-specific rules. Runs independently of GraphQL.
+    </p>
+    <table>
+      <tr><th>Category</th><th>Example (EN)</th><th>Confidence</th></tr>
+      <tr><td>Calendar event</td><td><code>tomorrow event at 3 PM</code></td><td>0.9</td></tr>
+      <tr><td>Navigation</td><td><code>open calendar</code></td><td>0.85</td></tr>
+      <tr><td>Invite</td><td><code>invite john@example.com</code></td><td>0.9</td></tr>
+      <tr><td>Create folder</td><td><code>create folder Vacation</code></td><td>0.8</td></tr>
+      <tr><td>Send message</td><td><code>send a message</code></td><td>0.75</td></tr>
+      <tr><td>Search files</td><td><code>find files report</code></td><td>0.7</td></tr>
+    </table>
+  </div>
+
+  <div class="card-small">
+    <h4><span class="emoji">&#x1F50D;</span> Source 3: GraphQL Search <span class="badge badge-purple">Server-Side</span></h4>
+    <p style="color:var(--text-muted);font-size:0.9rem;margin-bottom:0.75rem;">
+      Authenticated API call that fans out to 8 module search providers + command registry.
+    </p>
+    <table>
+      <tr><th>Returns</th><th>Source</th><th>Details</th></tr>
+      <tr><td><code>results[]</code></td><td>8 ISearchProvider</td><td>DB queries per module, capped at 30 total</td></tr>
+      <tr><td><code>commands[]</code></td><td>CommandPaletteRegistry</td><td>22 commands, filtered by permissions &amp; keywords</td></tr>
+    </table>
+  </div>
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">3</span> Data Transfer &mdash; What Gets Sent</h2>
+
+<h3>3.1 GraphQL Request</h3>
+<div class="card">
+<pre>query UniversalSearch($input: UniversalSearchRequestInput!) {
+  search {
+    universal(input: $input) {
+      results { title, description, module, icon, route }
+      commands { label, description, keywords, route,
+                 requiredPermissions, icon, group }
+    }
+  }
+}
+
+// Variables:
+{
+  "input": {
+    "query": "tomorrow event",   // User's search text
+    "modules": null,             // Optional module filter
+    "limit": 10,                 // Per-provider cap
+    "locale": "en"               // From LOCALE_ID
+  }
+}</pre>
+</div>
+
+<h3>3.2 Backend Processing Pipeline</h3>
+
+<div class="mermaid">
+sequenceDiagram
+    participant FE as Frontend
+    participant GQL as GraphQL QueryType
+    participant QH as QueryHandler
+    participant SP as SearchProviders
+    participant CR as CommandRegistry
+    participant DB as PostgreSQL
+
+    FE->>GQL: universal(input)
+    Note over GQL: Extract JWT claims<br/>Resolve user, family, permissions
+
+    GQL->>QH: UniversalSearchQuery
+    Note over QH: Build SearchContext<br/>(userId, familyId, query, limit, locale)
+
+    par Fan-out to providers
+        QH->>SP: FamilySearchProvider.SearchAsync()
+        SP->>DB: Query family, members, invitations
+        SP-->>QH: SearchResultItem[]
+    and
+        QH->>SP: CalendarSearchProvider.SearchAsync()
+        SP->>DB: Query events (9-month window)
+        SP-->>QH: SearchResultItem[]
+    and
+        QH->>SP: FileManagementSearchProvider.SearchAsync()
+        SP->>DB: Query files, folders, albums, tags
+        SP-->>QH: SearchResultItem[]
+    and
+        QH->>SP: MessagingSearchProvider.SearchAsync()
+        SP->>DB: Query messages
+        SP-->>QH: SearchResultItem[]
+    and
+        QH->>SP: ... (4 more providers)
+        SP-->>QH: SearchResultItem[]
+    end
+
+    Note over QH: Flatten + cap at 30 results
+
+    QH->>CR: GetAllCommands()
+    Note over CR: Singleton cache (22 commands)
+    CR-->>QH: CommandDescriptor[]
+
+    Note over QH: Filter by permissions<br/>Filter by keyword match<br/>Resolve locale labels (DE)
+
+    QH-->>GQL: UniversalSearchResult
+    GQL-->>FE: { results[], commands[] }
+</div>
+
+<h3>3.3 GraphQL Response</h3>
+<div class="card">
+<pre>{
+  "data": {
+    "search": {
+      "universal": {
+        "results": [
+          {
+            "title": "Weekly Team Standup",
+            "description": "Tomorrow at 10:00 AM",
+            "module": "calendar",
+            "icon": "calendar",
+            "route": "/family/calendar/events/abc-123"
+          }
+        ],
+        "commands": [
+          {
+            "label": "Create Event",
+            "description": "Add a new calendar event",
+            "keywords": ["create","new","event","add"],
+            "route": "/family/calendar?action=create",
+            "requiredPermissions": [],
+            "icon": "plus",
+            "group": "calendar"
+          }
+        ]
+      }
+    }
+  }
+}</pre>
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">4</span> Data Display &mdash; PaletteItem Mapping</h2>
+
+<p class="section-intro">
+  All three sources are normalized into a unified <code>PaletteItem[]</code> array.
+  The component groups items by consecutive <code>type</code> values and renders section headers automatically.
+</p>
+
+<div class="mermaid">
+flowchart LR
+    subgraph SOURCES["Data Sources"]
+        D["Default Items<br/>(8 items)"]
+        N["NLP Match<br/>(0-1 item)"]
+        R["GraphQL Results<br/>(0-30 items)"]
+        C["GraphQL Commands<br/>(0-22 items)"]
+    end
+
+    subgraph NORMALIZE["Normalize to PaletteItem"]
+        PI["PaletteItem {<br/>type, title, description,<br/>icon, route, module,<br/>confidence}"]
+    end
+
+    subgraph DISPLAY["Grouped Display"]
+        S1["&#x1F4A1; Try saying..."]
+        S2["&#x2728; Suggestions"]
+        S3["&#x1F50D; Search Results"]
+        S4["&#x26A1; Commands"]
+        S5["&#x1F3E0; Navigation"]
+    end
+
+    D --> PI
+    N --> PI
+    R --> PI
+    C --> PI
+
+    PI --> S1
+    PI --> S2
+    PI --> S3
+    PI --> S4
+    PI --> S5
+
+    style SOURCES fill:#1e293b,stroke:#3b82f6,color:#e2e8f0
+    style NORMALIZE fill:#1e4038,stroke:#22c55e,color:#e2e8f0
+    style DISPLAY fill:#3b1f5e,stroke:#8b5cf6,color:#e2e8f0
+</div>
+
+<table>
+  <thead>
+    <tr>
+      <th>PaletteItemType</th>
+      <th>Section Label</th>
+      <th>Emoji</th>
+      <th>Source</th>
+      <th>Click Behavior</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>hint</code></td>
+      <td>Try saying...</td>
+      <td>&#x1F4A1;</td>
+      <td>Default items (daily rotation)</td>
+      <td>Fills input + triggers NLP search</td>
+    </tr>
+    <tr>
+      <td><code>nlp</code></td>
+      <td>Suggestions</td>
+      <td>&#x2728;</td>
+      <td>NlpParserService (client-side regex)</td>
+      <td>Navigate to route</td>
+    </tr>
+    <tr>
+      <td><code>result</code></td>
+      <td>Search Results</td>
+      <td>Module emoji</td>
+      <td>GraphQL: 8 ISearchProvider (DB queries)</td>
+      <td>Navigate to route</td>
+    </tr>
+    <tr>
+      <td><code>command</code></td>
+      <td>Commands</td>
+      <td>&#x26A1;</td>
+      <td>GraphQL: CommandPaletteRegistry (singleton)</td>
+      <td>Navigate to route</td>
+    </tr>
+    <tr>
+      <td><code>navigation</code></td>
+      <td>Navigation</td>
+      <td>Module emoji</td>
+      <td>Default items (static)</td>
+      <td>Navigate to route</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ================================================================ -->
+<h2><span class="num">5</span> Search Providers &mdash; Per-Module Data Collection</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Module</th>
+      <th>Provider Class</th>
+      <th>What It Searches</th>
+      <th>Commands</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="badge badge-blue">Family</span></td>
+      <td>FamilySearchProvider</td>
+      <td>Family name, members (name/email), pending invitations</td>
+      <td>3 (View, Invite, Settings)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-green">Calendar</span></td>
+      <td>CalendarSearchProvider</td>
+      <td>Events in 9-month window (3 past, 6 future), sorts upcoming first</td>
+      <td>2 (Create Event, View Calendar)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-purple">Files</span></td>
+      <td>FileManagementSearchProvider</td>
+      <td>Files, folders, albums, tags, secure notes, share links</td>
+      <td>8 (Create Folder, Upload, Albums, etc.)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-pink">Messaging</span></td>
+      <td>MessagingSearchProvider</td>
+      <td>Messages by content, sorted newest first</td>
+      <td>2 (New Message, View Messages)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-cyan">Dashboard</span></td>
+      <td>DashboardSearchProvider</td>
+      <td>Personal &amp; family dashboards</td>
+      <td>1 (Open Dashboard)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-orange">EventChain</span></td>
+      <td>EventChainSearchProvider</td>
+      <td>Automation workflows by name/description</td>
+      <td>2 (Create Chain, View Chains)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-blue">Photos</span></td>
+      <td>PhotosSearchProvider</td>
+      <td>Photos by filename/caption, newest first</td>
+      <td>2 (Upload Photo, View Photos)</td>
+    </tr>
+    <tr>
+      <td><span class="badge badge-purple">Auth</span></td>
+      <td>&mdash; (no search provider)</td>
+      <td>&mdash;</td>
+      <td>2 (View Profile, Settings)</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ================================================================ -->
+<h2><span class="num">6</span> NLP Rules &mdash; Client-Side Intelligence</h2>
+
+<div class="mermaid">
+flowchart TD
+    Q["User Query<br/>'tomorrow event at 3 PM'"] --> MIN{"len >= 3?"}
+    MIN -->|No| NONE["Return null"]
+    MIN -->|Yes| LOCALE{"Locale?"}
+
+    LOCALE -->|"en"| EN["EN_RULES<br/>(17 regex patterns)"]
+    LOCALE -->|"de"| DE["DE_RULES<br/>(17 regex patterns)"]
+
+    EN --> MATCH["Try each pattern"]
+    DE --> MATCH
+
+    MATCH --> FOUND{"Match?"}
+    FOUND -->|No| NONE
+    FOUND -->|Yes| EXTRACT["extract(match)"]
+
+    EXTRACT --> CONF{"confidence > 0.5?"}
+    CONF -->|No| NONE
+    CONF -->|Yes| BEST["Return best NlpMatch"]
+
+    BEST --> RESULT["NlpMatch {<br/>type: 'create-event',<br/>confidence: 0.9,<br/>route: '/family/calendar?action=create<br/>&date=2026-03-06&time=15:00',<br/>description: 'Create event tomorrow at 3:00 PM'<br/>}"]
+
+    style Q fill:#1e3a5f,stroke:#3b82f6,color:#e2e8f0
+    style RESULT fill:#1e4038,stroke:#22c55e,color:#e2e8f0
+</div>
+
+<div class="card-grid">
+  <div class="card-small">
+    <h4>English NLP Actions</h4>
+    <ul>
+      <li><strong>Calendar:</strong> <code>tomorrow event at 3 PM</code> &rarr; create event with date+time</li>
+      <li><strong>Navigate:</strong> <code>open calendar</code>, <code>go to dashboard</code> &rarr; route directly</li>
+      <li><strong>Invite:</strong> <code>invite john@example.com</code> &rarr; pre-fill email</li>
+      <li><strong>Files:</strong> <code>create folder Vacation</code>, <code>upload a file</code></li>
+      <li><strong>Message:</strong> <code>send a message</code> &rarr; open compose</li>
+      <li><strong>Search:</strong> <code>find files report</code> &rarr; file search with query</li>
+    </ul>
+  </div>
+  <div class="card-small">
+    <h4>German NLP Actions</h4>
+    <ul>
+      <li><strong>Kalender:</strong> <code>morgen Termin um 15 Uhr</code> &rarr; Termin erstellen</li>
+      <li><strong>Navigation:</strong> <code>Kalender &ouml;ffnen</code>, <code>zum Dashboard gehen</code></li>
+      <li><strong>Einladen:</strong> <code>john@example.com einladen</code></li>
+      <li><strong>Dateien:</strong> <code>Ordner Urlaub erstellen</code>, <code>Datei hochladen</code></li>
+      <li><strong>Nachricht:</strong> <code>eine Nachricht senden</code></li>
+      <li><strong>Suche:</strong> <code>Dateien Bericht finden</code></li>
+    </ul>
+  </div>
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">7</span> Default Items &mdash; Daily Rotation</h2>
+
+<div class="card">
+<h3>Hint Rotation Algorithm</h3>
+<p style="color:var(--text-muted);margin-bottom:1rem;">
+  Two NLP hints are selected daily from a pool of 10 per locale, using deterministic epoch-day math.
+  All users see the same hints on the same day. The pool rotates every 10 days.
+</p>
+
+<div class="mermaid">
+flowchart LR
+    POOL["Hint Pool (10 items)<br/>'tomorrow event at 3 PM'<br/>'invite john@example.com'<br/>'open calendar'<br/>'create folder Vacation'<br/>'send a message'<br/>'event friday at 10 AM'<br/>'find files report'<br/>'go to dashboard'<br/>'create album Summer'<br/>'upload a file'"] --> CALC["daysSinceEpoch =<br/>floor(Date.now() / 86,400,000)"]
+
+    CALC --> IDX1["hint1 = pool[day % 10]"]
+    CALC --> IDX2["hint2 = pool[(day + 1) % 10]"]
+
+    IDX1 --> ITEMS["Default Items (8)"]
+    IDX2 --> ITEMS
+
+    ITEMS --> H1["&#x1F4A1; hint: 'open calendar'"]
+    ITEMS --> H2["&#x1F4A1; hint: 'create folder Vacation'"]
+    ITEMS --> C1["&#x26A1; command: Create Event"]
+    ITEMS --> C2["&#x26A1; command: Send Message"]
+    ITEMS --> N1["&#x1F3E0; nav: Dashboard"]
+    ITEMS --> N2["&#x1F4C5; nav: Calendar"]
+    ITEMS --> N3["&#x1F4AC; nav: Messages"]
+    ITEMS --> N4["&#x1F4C1; nav: Files"]
+
+    style POOL fill:#1e293b,stroke:#eab308,color:#e2e8f0
+    style ITEMS fill:#1e4038,stroke:#22c55e,color:#e2e8f0
+</div>
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">8</span> Component &mdash; UI Rendering</h2>
+
+<div class="card">
+<h3>Visual Structure</h3>
+<pre>
+&#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;
+&#x2502; &#x1F50D; Search or type a command...          [Esc] &#x2502;
+&#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;
+&#x2502;  TRY SAYING...                                    &#x2502;
+&#x2502;  &#x1F4A1; tomorrow event at 3 PM           [Enter] &#x2502;  &lt;-- hint (click = fill input)
+&#x2502;  &#x1F4A1; invite john@example.com                  &#x2502;  &lt;-- hint
+&#x2502;                                                    &#x2502;
+&#x2502;  COMMANDS                                          &#x2502;
+&#x2502;  &#x26A1; Create Event                     calendar &#x2502;  &lt;-- command
+&#x2502;     Add a new calendar event                       &#x2502;
+&#x2502;  &#x26A1; Send Message                     messages &#x2502;  &lt;-- command
+&#x2502;     Start a new conversation                       &#x2502;
+&#x2502;                                                    &#x2502;
+&#x2502;  NAVIGATION                                        &#x2502;
+&#x2502;  &#x1F3E0; Dashboard                       dashboard &#x2502;  &lt;-- navigation
+&#x2502;  &#x1F4C5; Calendar                        calendar &#x2502;  &lt;-- navigation
+&#x2502;  &#x1F4AC; Messages                        messages &#x2502;  &lt;-- navigation
+&#x2502;  &#x1F4C1; Files                              files &#x2502;  &lt;-- navigation
+&#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;
+&#x2502; [&#x2191;][&#x2193;] navigate  [Enter] select  [Esc] close  &#x2502;
+&#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;
+</pre>
+</div>
+
+<h3>Keyboard &amp; Interaction Model</h3>
+<table>
+  <tr><th>Input</th><th>Action</th></tr>
+  <tr><td><kbd>Ctrl+K</kbd> / <kbd>Cmd+K</kbd></td><td>Toggle palette open/closed</td></tr>
+  <tr><td><kbd>Esc</kbd></td><td>Close palette, restore previous focus</td></tr>
+  <tr><td><kbd>&uarr;</kbd> / <kbd>&darr;</kbd></td><td>Circular navigation through items</td></tr>
+  <tr><td><kbd>Enter</kbd></td><td>Execute selected item</td></tr>
+  <tr><td><kbd>Tab</kbd></td><td>Trapped (focus stays in modal)</td></tr>
+  <tr><td>Click item</td><td>Execute item</td></tr>
+  <tr><td>Click backdrop</td><td>Close palette</td></tr>
+  <tr><td>Type text (300ms debounce)</td><td>Trigger NLP + GraphQL search</td></tr>
+</table>
+
+<!-- ================================================================ -->
+<h2><span class="num">9</span> State Management &mdash; Signals</h2>
+
+<div class="mermaid">
+stateDiagram-v2
+    [*] --> Closed
+
+    Closed --> Open : Ctrl+K / toggle()
+    Open --> Closed : Esc / backdrop click
+
+    state Open {
+        [*] --> ShowingDefaults : items = getDefaultItems()
+        ShowingDefaults --> Searching : user types (300ms debounce)
+        Searching --> ShowingResults : performSearch() completes
+        ShowingResults --> Searching : user types more
+        ShowingResults --> ShowingDefaults : user clears input
+        Searching --> ShowingDefaults : user clears input
+        ShowingResults --> HintSearch : click hint item
+        HintSearch --> ShowingResults : performSearch() completes
+
+        ShowingDefaults --> Navigating : click command/nav item
+        ShowingResults --> Navigating : click any non-hint item
+    }
+
+    Navigating --> Closed : router.navigateByUrl()
+</div>
+
+<table>
+  <tr><th>Signal</th><th>Type</th><th>Purpose</th></tr>
+  <tr><td><code>isOpen</code></td><td><code>signal&lt;boolean&gt;</code></td><td>Palette visibility</td></tr>
+  <tr><td><code>query</code></td><td><code>signal&lt;string&gt;</code></td><td>Current search input text</td></tr>
+  <tr><td><code>selectedIndex</code></td><td><code>signal&lt;number&gt;</code></td><td>Keyboard-selected item index</td></tr>
+  <tr><td><code>isLoading</code></td><td><code>signal&lt;boolean&gt;</code></td><td>GraphQL request in flight</td></tr>
+  <tr><td><code>error</code></td><td><code>signal&lt;string | null&gt;</code></td><td>Error message for display</td></tr>
+  <tr><td><code>items</code></td><td><code>signal&lt;PaletteItem[]&gt;</code></td><td>Current items to render</td></tr>
+  <tr><td><code>hasItems</code></td><td><code>computed&lt;boolean&gt;</code></td><td>Derived: items.length &gt; 0</td></tr>
+</table>
+
+<!-- ================================================================ -->
+<h2><span class="num">10</span> Backend Registration &mdash; Module Pattern</h2>
+
+<div class="mermaid">
+flowchart TD
+    subgraph STARTUP["Application Startup"]
+        PM["Program.cs<br/>RegisterModule&lt;T&gt;()"]
+        SM["SearchModule<br/>(singleton registry)"]
+        INIT["CommandPaletteRegistryInitializer<br/>(IHostedService)"]
+    end
+
+    subgraph MODULES["Feature Modules (DI Registration)"]
+        FM["FamilyModule<br/>+ FamilySearchProvider (scoped)<br/>+ FamilyCommandPaletteProvider (singleton)"]
+        CM["CalendarModule<br/>+ CalendarSearchProvider (scoped)<br/>+ CalendarCommandPaletteProvider (singleton)"]
+        FMM["FileManagementModule<br/>+ FileManagementSearchProvider (scoped)<br/>+ FileManagementCommandPaletteProvider (singleton)"]
+        MM["MessagingModule<br/>+ MessagingSearchProvider (scoped)<br/>+ MessagingCommandPaletteProvider (singleton)"]
+        MORE["... (4 more modules)"]
+    end
+
+    subgraph REGISTRY["Runtime Registry"]
+        REG["CommandPaletteRegistry<br/>(22 commands cached)"]
+    end
+
+    PM --> SM
+    PM --> FM
+    PM --> CM
+    PM --> FMM
+    PM --> MM
+    PM --> MORE
+
+    SM --> INIT
+    INIT -->|"foreach provider<br/>registry.RegisterProvider()"| REG
+
+    FM -.->|provides| INIT
+    CM -.->|provides| INIT
+    FMM -.->|provides| INIT
+    MM -.->|provides| INIT
+    MORE -.->|provides| INIT
+
+    style STARTUP fill:#1e293b,stroke:#3b82f6,color:#e2e8f0
+    style MODULES fill:#3b1f5e,stroke:#8b5cf6,color:#e2e8f0
+    style REGISTRY fill:#1e4038,stroke:#22c55e,color:#e2e8f0
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">11</span> Internationalization (i18n)</h2>
+
+<div class="card-grid">
+  <div class="card-small">
+    <h4>Frontend i18n</h4>
+    <ul>
+      <li><strong>LOCALE_ID injection:</strong> selects EN or DE hint pool + NLP rules</li>
+      <li><strong>NLP rules:</strong> separate <code>en.rules.ts</code> / <code>de.rules.ts</code></li>
+      <li><strong>Date parsing:</strong> "tomorrow" vs "morgen", day names in both languages</li>
+      <li><strong>Time parsing:</strong> "3 PM" vs "15 Uhr"</li>
+      <li><strong>Hint pool:</strong> 10 EN phrases, 10 DE phrases</li>
+    </ul>
+  </div>
+  <div class="card-small">
+    <h4>Backend i18n</h4>
+    <ul>
+      <li><strong>CommandDescriptor:</strong> optional <code>LabelDe</code> + <code>DescriptionDe</code> fields</li>
+      <li><strong>Keywords:</strong> mixed-language arrays (e.g., <code>["invite", "einladen"]</code>)</li>
+      <li><strong>Locale parameter:</strong> passed through GraphQL, used for label resolution</li>
+      <li><strong>QueryHandler:</strong> <code>ResolveGermanLabels()</code> swaps labels when <code>locale=de</code></li>
+    </ul>
+  </div>
+</div>
+
+<!-- ================================================================ -->
+<h2><span class="num">12</span> Error Resilience</h2>
+
+<table>
+  <tr><th>Layer</th><th>Error Handling</th><th>Impact</th></tr>
+  <tr>
+    <td><span class="layer-fe">Frontend</span> NLP Parser</td>
+    <td>try/catch around <code>parse()</code></td>
+    <td>NLP fails silently; GraphQL search continues</td>
+  </tr>
+  <tr>
+    <td><span class="layer-fe">Frontend</span> SearchService</td>
+    <td>Returns empty result on GraphQL error</td>
+    <td>Palette shows "Search failed" error message</td>
+  </tr>
+  <tr>
+    <td><span class="layer-be">Backend</span> Per-provider</td>
+    <td>try/catch per <code>SearchAsync()</code> call</td>
+    <td>One provider fails; other 7 continue normally</td>
+  </tr>
+  <tr>
+    <td><span class="layer-gql">GraphQL</span> Auth</td>
+    <td><code>[Authorize]</code> on QueryType</td>
+    <td>Unauthenticated requests return GraphQL error</td>
+  </tr>
+</table>
+
+<!-- ================================================================ -->
+<h2><span class="num">13</span> File Map</h2>
+
+<div class="card">
+<pre>
+src/
+&#x251C;&#x2500;&#x2500; FamilyHub.Api/
+&#x2502;   &#x251C;&#x2500;&#x2500; Common/Search/
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; ISearchProvider.cs              &lt;-- interface: per-module search
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; ICommandPaletteProvider.cs       &lt;-- interface: per-module commands
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; ICommandPaletteRegistry.cs       &lt;-- interface: global registry
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; CommandPaletteRegistry.cs        &lt;-- singleton command store
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; CommandPaletteRegistryInit...cs  &lt;-- IHostedService startup
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; CommandDescriptor.cs            &lt;-- command model (+ i18n)
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; SearchContext.cs                &lt;-- provider input context
+&#x2502;   &#x2502;   &#x2514;&#x2500;&#x2500; SearchResultItem.cs             &lt;-- provider output model
+&#x2502;   &#x251C;&#x2500;&#x2500; Features/Search/
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; SearchModule.cs                 &lt;-- IModule registration
+&#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; Models/
+&#x2502;   &#x2502;   &#x2502;   &#x251C;&#x2500;&#x2500; UniversalSearchRequest.cs   &lt;-- GraphQL input
+&#x2502;   &#x2502;   &#x2502;   &#x2514;&#x2500;&#x2500; SearchResultItemDto.cs      &lt;-- GraphQL output
+&#x2502;   &#x2502;   &#x2514;&#x2500;&#x2500; Application/Queries/
+&#x2502;   &#x2502;       &#x2514;&#x2500;&#x2500; UniversalSearch/
+&#x2502;   &#x2502;           &#x251C;&#x2500;&#x2500; QueryType.cs                &lt;-- GraphQL resolver
+&#x2502;   &#x2502;           &#x251C;&#x2500;&#x2500; UniversalSearchQuery.cs     &lt;-- Mediator query
+&#x2502;   &#x2502;           &#x251C;&#x2500;&#x2500; UniversalSearchQueryHandler &lt;-- orchestrator
+&#x2502;   &#x2502;           &#x2514;&#x2500;&#x2500; UniversalSearchResult.cs    &lt;-- handler return
+&#x2502;   &#x2514;&#x2500;&#x2500; Features/{Module}/Application/Search/
+&#x2502;       &#x251C;&#x2500;&#x2500; {Module}SearchProvider.cs        &lt;-- ISearchProvider impl
+&#x2502;       &#x2514;&#x2500;&#x2500; {Module}CommandPaletteProvider.cs &lt;-- ICommandPaletteProvider impl
+&#x2502;
+&#x2514;&#x2500;&#x2500; frontend/family-hub-web/src/app/
+    &#x251C;&#x2500;&#x2500; core/nlp/
+    &#x2502;   &#x251C;&#x2500;&#x2500; nlp-parser.service.ts           &lt;-- regex-based NLP engine
+    &#x2502;   &#x251C;&#x2500;&#x2500; models.ts                       &lt;-- NlpMatch, NlpRule types
+    &#x2502;   &#x2514;&#x2500;&#x2500; rules/
+    &#x2502;       &#x251C;&#x2500;&#x2500; en.rules.ts                 &lt;-- 17 English patterns
+    &#x2502;       &#x251C;&#x2500;&#x2500; de.rules.ts                 &lt;-- 17 German patterns
+    &#x2502;       &#x251C;&#x2500;&#x2500; date-parser.ts              &lt;-- relative date resolution
+    &#x2502;       &#x2514;&#x2500;&#x2500; time-parser.ts              &lt;-- 12h/24h time parsing
+    &#x2514;&#x2500;&#x2500; shared/
+        &#x251C;&#x2500;&#x2500; models/search.models.ts         &lt;-- PaletteItem, SearchResultItem
+        &#x251C;&#x2500;&#x2500; graphql/search.operations.ts    &lt;-- GraphQL query definition
+        &#x251C;&#x2500;&#x2500; services/
+        &#x2502;   &#x251C;&#x2500;&#x2500; search.service.ts           &lt;-- Apollo GraphQL client
+        &#x2502;   &#x2514;&#x2500;&#x2500; command-palette.service.ts  &lt;-- state + orchestration
+        &#x251C;&#x2500;&#x2500; components/command-palette/
+        &#x2502;   &#x2514;&#x2500;&#x2500; command-palette.component.ts &lt;-- UI + keyboard handling
+        &#x2514;&#x2500;&#x2500; layout/
+            &#x2514;&#x2500;&#x2500; layout.component.ts          &lt;-- app shell (hosts palette)
+</pre>
+</div>
+
+<footer>
+  <p>Family Hub &mdash; Issue #208: Universal Search Command Palette &mdash; Generated 2026-03-05</p>
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      primaryColor: '#1e3a5f',
+      primaryTextColor: '#e2e8f0',
+      primaryBorderColor: '#3b82f6',
+      lineColor: '#64748b',
+      secondaryColor: '#3b1f5e',
+      tertiaryColor: '#1e4038',
+      fontFamily: 'Inter, sans-serif',
+      fontSize: '14px'
+    },
+    flowchart: { curve: 'basis' },
+    sequence: { actorMargin: 30 }
+  });
+</script>
+</body>
+</html>

--- a/src/FamilyHub.Api/Common/Development/DevDataSeeder.cs
+++ b/src/FamilyHub.Api/Common/Development/DevDataSeeder.cs
@@ -75,7 +75,9 @@ public sealed class DevDataSeeder(
         foreach (var kcUser in keycloakUsers)
         {
             if (string.IsNullOrWhiteSpace(kcUser.Email))
+            {
                 continue;
+            }
 
             var email = DomainEmail.From(kcUser.Email);
             var existingUser = await dbContext.Users
@@ -95,7 +97,10 @@ public sealed class DevDataSeeder(
             }
 
             var displayName = $"{kcUser.FirstName} {kcUser.LastName}".Trim();
-            if (displayName.Length < 2) displayName = kcUser.Username ?? kcUser.Email;
+            if (displayName.Length < 2)
+            {
+                displayName = kcUser.Username ?? kcUser.Email;
+            }
 
             var user = User.Register(
                 email,
@@ -155,12 +160,18 @@ public sealed class DevDataSeeder(
     private (string? BaseUrl, string? RealmName) ParseKeycloakAuthority()
     {
         var authority = configuration["Keycloak:Authority"];
-        if (string.IsNullOrWhiteSpace(authority)) return (null, null);
+        if (string.IsNullOrWhiteSpace(authority))
+        {
+            return (null, null);
+        }
 
         // Authority format: http://keycloak:8080/realms/FamilyHub-{env}
         const string realmsSegment = "/realms/";
         var realmsIndex = authority.IndexOf(realmsSegment, StringComparison.Ordinal);
-        if (realmsIndex < 0) return (null, null);
+        if (realmsIndex < 0)
+        {
+            return (null, null);
+        }
 
         var baseUrl = authority[..realmsIndex];
         var realmName = authority[(realmsIndex + realmsSegment.Length)..];

--- a/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationExtensions.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationExtensions.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-
 namespace FamilyHub.Api.Common.Infrastructure.Configuration.Infisical;
 
 public static class InfisicalConfigurationExtensions
@@ -8,17 +6,19 @@ public static class InfisicalConfigurationExtensions
     {
         // Bootstrap credentials come from environment variables (not IConfiguration)
         // to avoid circular dependency — this is the "secret zero" pattern.
-        var clientId = System.Environment.GetEnvironmentVariable("INFISICAL_CLIENT_ID");
-        var clientSecret = System.Environment.GetEnvironmentVariable("INFISICAL_CLIENT_SECRET");
+        var clientId = Environment.GetEnvironmentVariable("INFISICAL_CLIENT_ID");
+        var clientSecret = Environment.GetEnvironmentVariable("INFISICAL_CLIENT_SECRET");
 
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+        {
             return builder; // Infisical not configured — skip silently
+        }
 
         var options = new InfisicalOptions
         {
-            Url = System.Environment.GetEnvironmentVariable("INFISICAL_URL") ?? "http://localhost:8180",
-            ProjectId = System.Environment.GetEnvironmentVariable("INFISICAL_PROJECT_ID") ?? "",
-            Environment = System.Environment.GetEnvironmentVariable("INFISICAL_ENVIRONMENT") ?? "dev",
+            Url = Environment.GetEnvironmentVariable("INFISICAL_URL") ?? "http://localhost:8180",
+            ProjectId = Environment.GetEnvironmentVariable("INFISICAL_PROJECT_ID") ?? "",
+            Environment = Environment.GetEnvironmentVariable("INFISICAL_ENVIRONMENT") ?? "dev",
             ClientId = clientId,
             ClientSecret = clientSecret,
         };

--- a/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationProvider.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationProvider.cs
@@ -1,9 +1,5 @@
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace FamilyHub.Api.Common.Infrastructure.Configuration.Infisical;
 
@@ -34,7 +30,9 @@ public sealed class InfisicalConfigurationProvider : ConfigurationProvider
         {
             var accessToken = await AuthenticateAsync();
             if (string.IsNullOrEmpty(accessToken))
+            {
                 return;
+            }
 
             var secrets = await FetchSecretsAsync(accessToken);
             foreach (var secret in secrets)

--- a/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationSource.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/Configuration/Infisical/InfisicalConfigurationSource.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-
 namespace FamilyHub.Api.Common.Infrastructure.Configuration.Infisical;
 
 public sealed class InfisicalConfigurationSource(InfisicalOptions options) : IConfigurationSource

--- a/src/FamilyHub.Api/Common/Infrastructure/GraphQL/BusinessLogicExceptionErrorFilter.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/GraphQL/BusinessLogicExceptionErrorFilter.cs
@@ -15,32 +15,34 @@ public sealed class BusinessLogicExceptionErrorFilter(
 {
     public IError OnError(IError error)
     {
-        if (error.Exception is DomainException domainEx)
+        switch (error.Exception)
         {
-            var message = GetLocalizedMessage(domainEx);
+            case DomainException domainEx:
+            {
+                var message = GetLocalizedMessage(domainEx);
 
-            return ErrorBuilder.New()
-                .SetMessage(message)
-                .SetCode("BUSINESS_LOGIC_ERROR")
-                .SetExtension("errorCode", domainEx.ErrorCode)
-                .Build();
+                return ErrorBuilder.New()
+                    .SetMessage(message)
+                    .SetCode("BUSINESS_LOGIC_ERROR")
+                    .SetExtension("errorCode", domainEx.ErrorCode)
+                    .Build();
+            }
+            case InvalidOperationException ex:
+                return ErrorBuilder.New()
+                    .SetMessage(ex.Message)
+                    .SetCode("BUSINESS_LOGIC_ERROR")
+                    .Build();
+            default:
+                return error;
         }
-
-        if (error.Exception is InvalidOperationException ex)
-        {
-            return ErrorBuilder.New()
-                .SetMessage(ex.Message)
-                .SetCode("BUSINESS_LOGIC_ERROR")
-                .Build();
-        }
-
-        return error;
     }
 
     private string GetLocalizedMessage(DomainException ex)
     {
         if (ex.ErrorCode is null)
+        {
             return ex.Message;
+        }
 
         var localized = localizer[ex.ErrorCode];
         // If the key is not found, IStringLocalizer returns the key itself — fall back to exception message

--- a/src/FamilyHub.Api/Common/Infrastructure/GraphQL/NamespaceTypes/FileManagementMutation.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/GraphQL/NamespaceTypes/FileManagementMutation.cs
@@ -1,5 +1,3 @@
-using HotChocolate.Authorization;
-
 namespace FamilyHub.Api.Common.Infrastructure.GraphQL.NamespaceTypes;
 
 /// <summary>

--- a/src/FamilyHub.Api/Common/Infrastructure/GraphQL/RequestExecutorBuilderExtensions.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/GraphQL/RequestExecutorBuilderExtensions.cs
@@ -13,8 +13,8 @@ public static class RequestExecutorBuilderExtensions
         this IRequestExecutorBuilder builder, Assembly assembly)
     {
         var extensionTypes = assembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract
-                && Attribute.IsDefined(t, typeof(ExtendObjectTypeAttribute), inherit: true));
+            .Where(t => t is { IsClass: true, IsAbstract: false }
+                        && Attribute.IsDefined(t, typeof(ExtendObjectTypeAttribute), inherit: true));
 
         foreach (var type in extensionTypes)
         {

--- a/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/HealthCheckResponseWriter.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/HealthCheckResponseWriter.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Text.Json;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -16,7 +17,7 @@ public static class HealthCheckResponseWriter
 
     public static async Task WriteResponse(HttpContext context, HealthReport report)
     {
-        context.Response.ContentType = "application/json";
+        context.Response.ContentType = MediaTypeNames.Application.Json;
 
         var checks = report.Entries.ToDictionary(
             entry => entry.Key,

--- a/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/JwtSigningKeysHealthCheck.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/JwtSigningKeysHealthCheck.cs
@@ -17,7 +17,9 @@ public class JwtSigningKeysHealthCheck(IOptionsMonitor<JwtBearerOptions> jwtOpti
         {
             var options = jwtOptions.Get(JwtBearerDefaults.AuthenticationScheme);
             if (options.ConfigurationManager is null)
+            {
                 return HealthCheckResult.Degraded("OIDC ConfigurationManager not configured");
+            }
 
             var config = await options.ConfigurationManager.GetConfigurationAsync(cancellationToken);
             var keyCount = config.SigningKeys.Count;

--- a/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/KeycloakHealthCheck.cs
+++ b/src/FamilyHub.Api/Common/Infrastructure/HealthChecks/KeycloakHealthCheck.cs
@@ -16,13 +16,14 @@ public class KeycloakHealthCheck(IOptionsMonitor<JwtBearerOptions> jwtOptions) :
         {
             var options = jwtOptions.Get(JwtBearerDefaults.AuthenticationScheme);
             if (options.ConfigurationManager is null)
+            {
                 return HealthCheckResult.Degraded("OIDC ConfigurationManager not configured");
+            }
 
             var config = await options.ConfigurationManager.GetConfigurationAsync(cancellationToken);
-            if (string.IsNullOrEmpty(config.Issuer))
-                return HealthCheckResult.Unhealthy("OIDC discovery returned empty issuer");
-
-            return HealthCheckResult.Healthy($"OIDC discovery loaded (issuer: {config.Issuer})");
+            return string.IsNullOrEmpty(config.Issuer)
+                ? HealthCheckResult.Unhealthy("OIDC discovery returned empty issuer")
+                : HealthCheckResult.Healthy($"OIDC discovery loaded (issuer: {config.Issuer})");
         }
         catch (Exception ex)
         {

--- a/src/FamilyHub.Api/Features/Auth/Application/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/Auth/Application/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
@@ -20,7 +20,10 @@ public sealed class GetCurrentUserQueryHandler(
         CancellationToken cancellationToken)
     {
         var user = await userRepository.GetByExternalIdAsync(query.ExternalUserId, cancellationToken);
-        if (user is null) return null;
+        if (user is null)
+        {
+            return null;
+        }
 
         var dto = UserMapper.ToDto(user);
 

--- a/src/FamilyHub.Api/Features/Auth/Domain/Entities/User.cs
+++ b/src/FamilyHub.Api/Features/Auth/Domain/Entities/User.cs
@@ -233,7 +233,10 @@ public sealed class User : AggregateRoot<UserId>
     /// </summary>
     public void RemoveAvatar()
     {
-        if (AvatarId is null) return;
+        if (AvatarId is null)
+        {
+            return;
+        }
 
         var previousAvatarId = AvatarId.Value;
         AvatarId = null;

--- a/src/FamilyHub.Api/Features/Auth/GraphQL/AuthQueries.cs
+++ b/src/FamilyHub.Api/Features/Auth/GraphQL/AuthQueries.cs
@@ -31,7 +31,7 @@ public class MeProfileQueryExtension
         var externalUserId = ExternalUserId.From(externalUserIdString);
         var query = new GetCurrentUserQuery(externalUserId);
 
-        return await queryBus.QueryAsync<UserDto?>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 }
 
@@ -52,6 +52,6 @@ public class UsersQueryExtension
         var userIdVo = UserId.From(userId);
         var query = new GetUserByIdQuery(userIdVo);
 
-        return await queryBus.QueryAsync<UserDto?>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 }

--- a/src/FamilyHub.Api/Features/Calendar/Application/Search/CalendarSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/Calendar/Application/Search/CalendarSearchProvider.cs
@@ -12,7 +12,9 @@ public sealed class CalendarSearchProvider(ICalendarEventRepository calendarEven
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null || string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         var now = DateTime.UtcNow;
         var start = now.AddMonths(-3);

--- a/src/FamilyHub.Api/Features/Calendar/GraphQL/CalendarMutations.cs
+++ b/src/FamilyHub.Api/Features/Calendar/GraphQL/CalendarMutations.cs
@@ -9,6 +9,7 @@ using FamilyHub.Api.Features.Calendar.Domain.ValueObjects;
 using FamilyHub.Api.Features.Calendar.Models;
 using HotChocolate.Authorization;
 using System.Security.Claims;
+using FamilyHub.Api.Common.Infrastructure;
 
 namespace FamilyHub.Api.Features.Calendar.GraphQL;
 
@@ -24,7 +25,7 @@ public class CalendarMutations
         [Service] IUserRepository userRepository,
         CancellationToken ct)
     {
-        var externalUserIdString = claimsPrincipal.FindFirst("sub")?.Value
+        var externalUserIdString = claimsPrincipal.FindFirst(ClaimNames.Sub)?.Value
             ?? throw new UnauthorizedAccessException("User not authenticated");
 
         var externalUserId = ExternalUserId.From(externalUserIdString);
@@ -37,7 +38,7 @@ public class CalendarMutations
         }
 
         var title = EventTitle.From(input.Title.Trim());
-        var attendeeIds = input.AttendeeIds.Select(id => UserId.From(id)).ToList();
+        var attendeeIds = input.AttendeeIds.Select(UserId.From).ToList();
 
         var command = new CreateCalendarEventCommand(
             user.FamilyId.Value,
@@ -50,7 +51,7 @@ public class CalendarMutations
             input.IsAllDay,
             attendeeIds);
 
-        var result = await commandBus.SendAsync<CreateCalendarEventResult>(command, ct);
+        var result = await commandBus.SendAsync(command, ct);
 
         var created = await repository.GetByIdWithAttendeesAsync(result.CalendarEventId, ct)
             ?? throw new InvalidOperationException("Event creation failed");
@@ -68,7 +69,7 @@ public class CalendarMutations
         [Service] IUserRepository userRepository,
         CancellationToken ct)
     {
-        var externalUserIdString = claimsPrincipal.FindFirst("sub")?.Value
+        var externalUserIdString = claimsPrincipal.FindFirst(ClaimNames.Sub)?.Value
             ?? throw new UnauthorizedAccessException("User not authenticated");
 
         var externalUserId = ExternalUserId.From(externalUserIdString);
@@ -77,7 +78,7 @@ public class CalendarMutations
 
         var calendarEventId = CalendarEventId.From(id);
         var title = EventTitle.From(input.Title.Trim());
-        var attendeeIds = input.AttendeeIds.Select(uid => UserId.From(uid)).ToList();
+        var attendeeIds = input.AttendeeIds.Select(UserId.From).ToList();
 
         var command = new UpdateCalendarEventCommand(
             calendarEventId,
@@ -89,7 +90,7 @@ public class CalendarMutations
             input.IsAllDay,
             attendeeIds);
 
-        var result = await commandBus.SendAsync<UpdateCalendarEventResult>(command, ct);
+        var result = await commandBus.SendAsync(command, ct);
 
         var updated = await repository.GetByIdWithAttendeesAsync(result.CalendarEventId, ct)
             ?? throw new InvalidOperationException("Event update failed");
@@ -105,7 +106,7 @@ public class CalendarMutations
         [Service] IUserRepository userRepository,
         CancellationToken ct)
     {
-        var externalUserIdString = claimsPrincipal.FindFirst("sub")?.Value
+        var externalUserIdString = claimsPrincipal.FindFirst(ClaimNames.Sub)?.Value
             ?? throw new UnauthorizedAccessException("User not authenticated");
 
         var externalUserId = ExternalUserId.From(externalUserIdString);
@@ -115,7 +116,7 @@ public class CalendarMutations
         var calendarEventId = CalendarEventId.From(id);
         var command = new CancelCalendarEventCommand(calendarEventId);
 
-        var result = await commandBus.SendAsync<CancelCalendarEventResult>(command, ct);
+        var result = await commandBus.SendAsync(command, ct);
         return result.Success;
     }
 }

--- a/src/FamilyHub.Api/Features/Calendar/GraphQL/CalendarQueries.cs
+++ b/src/FamilyHub.Api/Features/Calendar/GraphQL/CalendarQueries.cs
@@ -24,7 +24,7 @@ public class CalendarQueries
             startDate,
             endDate);
 
-        return await queryBus.QueryAsync<List<CalendarEventDto>>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 
     [Authorize]
@@ -34,6 +34,6 @@ public class CalendarQueries
         CancellationToken ct)
     {
         var query = new GetCalendarEventQuery(CalendarEventId.From(id));
-        return await queryBus.QueryAsync<CalendarEventDto?>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 }

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Commands/AddWidget/AddWidgetCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Commands/AddWidget/AddWidgetCommandHandler.cs
@@ -17,10 +17,12 @@ public sealed class AddWidgetCommandHandler(
         CancellationToken cancellationToken)
     {
         if (!widgetRegistry.IsValidWidget(command.WidgetType.Value))
+        {
             throw new DomainException($"Invalid widget type: {command.WidgetType.Value}");
+        }
 
         var dashboard = await dashboardRepository.GetByIdAsync(command.DashboardId, cancellationToken)
-            ?? throw new DomainException($"Dashboard {command.DashboardId} not found");
+                        ?? throw new DomainException($"Dashboard {command.DashboardId} not found");
 
         var sortOrder = dashboard.Widgets.Count;
         var widget = dashboard.AddWidget(

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Commands/AddWidget/MutationType.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Commands/AddWidget/MutationType.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using FamilyHub.Common.Application;
 using FamilyHub.Api.Common.Infrastructure.GraphQL.NamespaceTypes;
 using FamilyHub.Api.Features.Dashboard.Domain.ValueObjects;

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Commands/SaveDashboardLayout/SaveDashboardLayoutCommand.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Commands/SaveDashboardLayout/SaveDashboardLayoutCommand.cs
@@ -1,7 +1,6 @@
 using FamilyHub.Common.Application;
 using FamilyHub.Common.Domain.ValueObjects;
 using FamilyHub.Api.Features.Dashboard.Domain.ValueObjects;
-using FamilyHub.Api.Features.Dashboard.Models;
 
 namespace FamilyHub.Api.Features.Dashboard.Application.Commands.SaveDashboardLayout;
 

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Commands/SaveDashboardLayout/SaveDashboardLayoutCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Commands/SaveDashboardLayout/SaveDashboardLayoutCommandHandler.cs
@@ -3,7 +3,6 @@ using FamilyHub.Common.Domain;
 using FamilyHub.Api.Common.Widgets;
 using FamilyHub.Api.Features.Dashboard.Domain.Entities;
 using FamilyHub.Api.Features.Dashboard.Domain.Repositories;
-using FamilyHub.Api.Features.Dashboard.Domain.ValueObjects;
 
 namespace FamilyHub.Api.Features.Dashboard.Application.Commands.SaveDashboardLayout;
 
@@ -20,14 +19,16 @@ public sealed class SaveDashboardLayoutCommandHandler(
         foreach (var widget in command.Widgets)
         {
             if (!widgetRegistry.IsValidWidget(widget.WidgetType.Value))
+            {
                 throw new DomainException($"Invalid widget type: {widget.WidgetType.Value}");
+            }
         }
 
         // Get or create dashboard
         DashboardLayout? dashboard;
         var isNew = false;
 
-        if (command.IsShared && command.FamilyId.HasValue)
+        if (command is { IsShared: true, FamilyId: not null })
         {
             dashboard = await dashboardRepository.GetSharedDashboardAsync(command.FamilyId.Value, cancellationToken);
             if (dashboard is null)
@@ -60,9 +61,13 @@ public sealed class SaveDashboardLayoutCommandHandler(
 
         // Persist
         if (isNew)
+        {
             await dashboardRepository.AddAsync(dashboard, cancellationToken);
+        }
         else
+        {
             await dashboardRepository.UpdateAsync(dashboard, cancellationToken);
+        }
 
         await dashboardRepository.SaveChangesAsync(cancellationToken);
 

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Queries/GetFamilyDashboard/QueryType.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Queries/GetFamilyDashboard/QueryType.cs
@@ -21,12 +21,16 @@ public class QueryType
     {
         var externalUserIdString = claimsPrincipal.FindFirst(ClaimNames.Sub)?.Value;
         if (string.IsNullOrEmpty(externalUserIdString))
+        {
             return null;
+        }
 
         var user = await userRepository.GetByExternalIdAsync(
             ExternalUserId.From(externalUserIdString), cancellationToken);
         if (user?.FamilyId is null)
+        {
             return null;
+        }
 
         var query = new GetFamilyDashboardQuery(user.FamilyId.Value);
         return await queryBus.QueryAsync(query, cancellationToken);

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Queries/GetMyDashboard/QueryType.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Queries/GetMyDashboard/QueryType.cs
@@ -21,12 +21,16 @@ public class QueryType
     {
         var externalUserIdString = claimsPrincipal.FindFirst(ClaimNames.Sub)?.Value;
         if (string.IsNullOrEmpty(externalUserIdString))
+        {
             return null;
+        }
 
         var user = await userRepository.GetByExternalIdAsync(
             ExternalUserId.From(externalUserIdString), cancellationToken);
         if (user is null)
+        {
             return null;
+        }
 
         var query = new GetMyDashboardQuery(user.Id);
         return await queryBus.QueryAsync(query, cancellationToken);

--- a/src/FamilyHub.Api/Features/Dashboard/Application/Search/DashboardSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Application/Search/DashboardSearchProvider.cs
@@ -12,7 +12,9 @@ public sealed class DashboardSearchProvider(IDashboardLayoutRepository dashboard
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         var queryLower = context.Query.ToLowerInvariant();
         var isGerman = context.Locale?.StartsWith("de", StringComparison.OrdinalIgnoreCase) == true;

--- a/src/FamilyHub.Api/Features/Dashboard/Domain/Entities/DashboardLayout.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Domain/Entities/DashboardLayout.cs
@@ -77,7 +77,9 @@ public sealed class DashboardLayout : AggregateRoot<DashboardId>
     {
         var widget = _widgets.FirstOrDefault(w => w.Id == widgetId);
         if (widget is null)
+        {
             throw new DomainException($"Widget {widgetId} not found in dashboard {Id}");
+        }
 
         _widgets.Remove(widget);
         UpdatedAt = DateTime.UtcNow;

--- a/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardId.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardId.cs
@@ -10,7 +10,9 @@ public readonly partial struct DashboardId
     private static Validation Validate(Guid value)
     {
         if (value == Guid.Empty)
+        {
             return Validation.Invalid("Dashboard ID cannot be empty");
+        }
 
         return Validation.Ok;
     }

--- a/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardLayoutName.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardLayoutName.cs
@@ -8,10 +8,14 @@ public readonly partial struct DashboardLayoutName
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Dashboard layout name is required");
+        }
 
         if (value.Length > 100)
+        {
             return Validation.Invalid("Dashboard layout name too long (max 100 characters)");
+        }
 
         return Validation.Ok;
     }

--- a/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardWidgetId.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/DashboardWidgetId.cs
@@ -10,7 +10,9 @@ public readonly partial struct DashboardWidgetId
     private static Validation Validate(Guid value)
     {
         if (value == Guid.Empty)
+        {
             return Validation.Invalid("Dashboard widget ID cannot be empty");
+        }
 
         return Validation.Ok;
     }

--- a/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/WidgetTypeId.cs
+++ b/src/FamilyHub.Api/Features/Dashboard/Domain/ValueObjects/WidgetTypeId.cs
@@ -8,10 +8,14 @@ public readonly partial struct WidgetTypeId
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Widget type ID is required");
+        }
 
         if (value.Length > 100)
+        {
             return Validation.Invalid("Widget type ID too long (max 100 characters)");
+        }
 
         return Validation.Ok;
     }

--- a/src/FamilyHub.Api/Features/EventChain/Application/Commands/CreateChainDefinition/CreateChainDefinitionCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/EventChain/Application/Commands/CreateChainDefinition/CreateChainDefinitionCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class CreateChainDefinitionCommandHandler(
     {
         // Validate trigger exists in registry
         if (!registry.IsValidTrigger(command.TriggerEventType))
+        {
             throw new InvalidOperationException($"Unknown trigger event type: {command.TriggerEventType}");
+        }
 
         var trigger = registry.GetTrigger(command.TriggerEventType)!;
 
@@ -34,8 +36,10 @@ public sealed class CreateChainDefinitionCommandHandler(
         foreach (var stepCmd in command.Steps.OrderBy(s => s.Order))
         {
             if (!registry.IsValidAction(stepCmd.ActionType, stepCmd.ActionVersion.Value))
+            {
                 throw new InvalidOperationException(
                     $"Unknown action: {stepCmd.ActionType}@{stepCmd.ActionVersion.Value}");
+            }
 
             var action = registry.GetAction(stepCmd.ActionType, stepCmd.ActionVersion.Value)!;
 

--- a/src/FamilyHub.Api/Features/EventChain/Application/Commands/UpdateChainDefinition/UpdateChainDefinitionCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/EventChain/Application/Commands/UpdateChainDefinition/UpdateChainDefinitionCommandHandler.cs
@@ -27,8 +27,10 @@ public sealed class UpdateChainDefinitionCommandHandler(
             foreach (var stepCmd in command.Steps.OrderBy(s => s.Order))
             {
                 if (!registry.IsValidAction(stepCmd.ActionType, stepCmd.ActionVersion.Value))
+                {
                     throw new InvalidOperationException(
                         $"Unknown action: {stepCmd.ActionType}@{stepCmd.ActionVersion.Value}");
+                }
 
                 var action = registry.GetAction(stepCmd.ActionType, stepCmd.ActionVersion.Value)!;
 

--- a/src/FamilyHub.Api/Features/EventChain/Application/Search/EventChainSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/EventChain/Application/Search/EventChainSearchProvider.cs
@@ -12,7 +12,9 @@ public sealed class EventChainSearchProvider(IChainDefinitionRepository chainDef
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null || string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         var definitions = await chainDefinitionRepository.GetByFamilyIdAsync(
             context.FamilyId.Value, ct: cancellationToken);

--- a/src/FamilyHub.Api/Features/EventChain/GraphQL/ChainMutations.cs
+++ b/src/FamilyHub.Api/Features/EventChain/GraphQL/ChainMutations.cs
@@ -50,7 +50,7 @@ public class ChainMutations
                     s.Order)).ToList(),
                 input.IsEnabled);
 
-            var result = await commandBus.SendAsync<CreateChainDefinitionResult>(command, ct);
+            var result = await commandBus.SendAsync(command, ct);
             var definition = await definitionRepository.GetByIdWithStepsAsync(result.ChainDefinitionId, ct);
             return new CreateChainDefinitionPayload(definition is not null ? ChainMapper.ToDto(definition) : null);
         }
@@ -90,7 +90,7 @@ public class ChainMutations
                     s.Condition,
                     s.Order)).ToList());
 
-            var result = await commandBus.SendAsync<UpdateChainDefinitionResult>(command, ct);
+            var result = await commandBus.SendAsync(command, ct);
             var definition = await definitionRepository.GetByIdWithStepsAsync(result.ChainDefinitionId, ct);
             var count = await executionRepository.GetExecutionCountAsync(result.ChainDefinitionId, ct);
             var lastExec = await executionRepository.GetLastExecutedAtAsync(result.ChainDefinitionId, ct);
@@ -116,7 +116,7 @@ public class ChainMutations
             var (userId, familyId) = await ResolveUserContext(claimsPrincipal, userRepository, ct);
 
             var command = new DeleteChainDefinitionCommand(ChainDefinitionId.From(id));
-            var result = await commandBus.SendAsync<DeleteChainDefinitionResult>(command, ct);
+            var result = await commandBus.SendAsync(command, ct);
             return new DeleteChainDefinitionPayload(result.Success);
         }
         catch (Exception ex)
@@ -135,7 +135,7 @@ public class ChainMutations
         CancellationToken ct)
     {
         var command = new EnableChainDefinitionCommand(ChainDefinitionId.From(id));
-        var defId = await commandBus.SendAsync<ChainDefinitionId>(command, ct);
+        var defId = await commandBus.SendAsync(command, ct);
         var definition = await definitionRepository.GetByIdWithStepsAsync(defId, ct)
             ?? throw new InvalidOperationException("Chain definition not found");
         var count = await executionRepository.GetExecutionCountAsync(defId, ct);
@@ -152,7 +152,7 @@ public class ChainMutations
         CancellationToken ct)
     {
         var command = new DisableChainDefinitionCommand(ChainDefinitionId.From(id));
-        var defId = await commandBus.SendAsync<ChainDefinitionId>(command, ct);
+        var defId = await commandBus.SendAsync(command, ct);
         var definition = await definitionRepository.GetByIdWithStepsAsync(defId, ct)
             ?? throw new InvalidOperationException("Chain definition not found");
         var count = await executionRepository.GetExecutionCountAsync(defId, ct);
@@ -177,7 +177,7 @@ public class ChainMutations
             familyId,
             triggerPayload);
 
-        var result = await commandBus.SendAsync<ExecuteChainResult>(command, ct);
+        var result = await commandBus.SendAsync(command, ct);
 
         // Give execution a moment to start
         await Task.Delay(100, ct);
@@ -200,7 +200,9 @@ public class ChainMutations
             ?? throw new UnauthorizedAccessException("User not found");
 
         if (!user.FamilyId.HasValue)
+        {
             throw new InvalidOperationException("User is not assigned to a family");
+        }
 
         return (user.Id, user.FamilyId.Value);
     }

--- a/src/FamilyHub.Api/Features/EventChain/GraphQL/ChainQueries.cs
+++ b/src/FamilyHub.Api/Features/EventChain/GraphQL/ChainQueries.cs
@@ -28,7 +28,7 @@ public class ChainQueries
         CancellationToken ct)
     {
         var query = new GetChainDefinitionsQuery(FamilyId.From(familyId), isEnabled);
-        var definitions = await queryBus.QueryAsync<IReadOnlyList<ChainDefinition>>(query, ct);
+        var definitions = await queryBus.QueryAsync(query, ct);
 
         var result = new List<ChainDefinitionDto>();
         foreach (var def in definitions)
@@ -49,9 +49,12 @@ public class ChainQueries
         CancellationToken ct)
     {
         var query = new GetChainDefinitionQuery(ChainDefinitionId.From(id));
-        var definition = await queryBus.QueryAsync<ChainDefinition?>(query, ct);
+        var definition = await queryBus.QueryAsync(query, ct);
 
-        if (definition is null) return null;
+        if (definition is null)
+        {
+            return null;
+        }
 
         var count = await executionRepository.GetExecutionCountAsync(definition.Id, ct);
         var lastExec = await executionRepository.GetLastExecutedAtAsync(definition.Id, ct);
@@ -71,7 +74,7 @@ public class ChainQueries
             chainDefinitionId.HasValue ? ChainDefinitionId.From(chainDefinitionId.Value) : null,
             status);
 
-        var executions = await queryBus.QueryAsync<IReadOnlyList<ChainExecution>>(query, ct);
+        var executions = await queryBus.QueryAsync(query, ct);
         return executions.Select(ChainMapper.ToDto).ToList();
     }
 
@@ -82,7 +85,7 @@ public class ChainQueries
         CancellationToken ct)
     {
         var query = new GetChainExecutionQuery(ChainExecutionId.From(id));
-        var execution = await queryBus.QueryAsync<ChainExecution?>(query, ct);
+        var execution = await queryBus.QueryAsync(query, ct);
         return execution is null ? null : ChainMapper.ToDto(execution);
     }
 

--- a/src/FamilyHub.Api/Features/EventChain/Infrastructure/Repositories/ChainDefinitionRepository.cs
+++ b/src/FamilyHub.Api/Features/EventChain/Infrastructure/Repositories/ChainDefinitionRepository.cs
@@ -29,7 +29,9 @@ public sealed class ChainDefinitionRepository(AppDbContext context) : IChainDefi
             .Where(d => d.FamilyId == familyId);
 
         if (isEnabled.HasValue)
+        {
             query = query.Where(d => d.IsEnabled == isEnabled.Value);
+        }
 
         return await query.OrderBy(d => d.CreatedAt).ToListAsync(ct);
     }

--- a/src/FamilyHub.Api/Features/EventChain/Infrastructure/Repositories/ChainExecutionRepository.cs
+++ b/src/FamilyHub.Api/Features/EventChain/Infrastructure/Repositories/ChainExecutionRepository.cs
@@ -34,10 +34,14 @@ public sealed class ChainExecutionRepository(AppDbContext context) : IChainExecu
             .Where(e => e.FamilyId == familyId);
 
         if (chainDefinitionId.HasValue)
+        {
             query = query.Where(e => e.ChainDefinitionId == chainDefinitionId.Value);
+        }
 
         if (status.HasValue)
+        {
             query = query.Where(e => e.Status == status.Value);
+        }
 
         return await query.OrderByDescending(e => e.StartedAt).ToListAsync(ct);
     }
@@ -53,7 +57,9 @@ public sealed class ChainExecutionRepository(AppDbContext context) : IChainExecu
         var query = context.ChainEntityMappings.Where(m => m.EntityId == entityId);
 
         if (entityType is not null)
+        {
             query = query.Where(m => m.EntityType == entityType);
+        }
 
         return await query.ToListAsync(ct);
     }

--- a/src/FamilyHub.Api/Features/Family/Application/Commands/UploadAvatar/UploadAvatarCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/Family/Application/Commands/UploadAvatar/UploadAvatarCommandHandler.cs
@@ -30,8 +30,7 @@ public sealed class UploadAvatarCommandHandler(
 
         // Build optional crop area
         CropArea? cropArea = null;
-        if (command.CropX.HasValue && command.CropY.HasValue &&
-            command.CropWidth.HasValue && command.CropHeight.HasValue)
+        if (command is { CropX: not null, CropY: not null, CropWidth: not null, CropHeight: not null })
         {
             cropArea = new CropArea(
                 command.CropX.Value, command.CropY.Value,

--- a/src/FamilyHub.Api/Features/Family/Application/Search/FamilySearchProvider.cs
+++ b/src/FamilyHub.Api/Features/Family/Application/Search/FamilySearchProvider.cs
@@ -1,6 +1,5 @@
 using FamilyHub.Api.Common.Search;
 using FamilyHub.Api.Features.Family.Domain.Repositories;
-using FamilyHub.Api.Features.Family.Domain.ValueObjects;
 
 namespace FamilyHub.Api.Features.Family.Application.Search;
 
@@ -16,7 +15,9 @@ public sealed class FamilySearchProvider(
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null)
+        {
             return [];
+        }
 
         var queryLower = context.Query.ToLowerInvariant();
         var isGerman = context.Locale?.StartsWith("de", StringComparison.OrdinalIgnoreCase) == true;

--- a/src/FamilyHub.Api/Features/Family/Domain/Entities/FamilyMember.cs
+++ b/src/FamilyHub.Api/Features/Family/Domain/Entities/FamilyMember.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.Auth.Domain.Entities;
-using FamilyHub.Common.Domain;
 using FamilyHub.Common.Domain.ValueObjects;
 using FamilyHub.Api.Features.Family.Domain.ValueObjects;
 

--- a/src/FamilyHub.Api/Features/Family/Domain/ValueObjects/FamilyRole.cs
+++ b/src/FamilyHub.Api/Features/Family/Domain/ValueObjects/FamilyRole.cs
@@ -40,12 +40,36 @@ public readonly partial struct FamilyRole
     public List<string> GetPermissions()
     {
         var permissions = new List<string>();
-        if (CanInvite()) permissions.Add("family:invite");
-        if (CanRevokeInvitation()) permissions.Add("family:revoke-invitation");
-        if (CanRemoveMembers()) permissions.Add("family:remove-members");
-        if (CanEditFamily()) permissions.Add("family:edit");
-        if (CanDeleteFamily()) permissions.Add("family:delete");
-        if (CanManageRoles()) permissions.Add("family:manage-roles");
+        if (CanInvite())
+        {
+            permissions.Add("family:invite");
+        }
+
+        if (CanRevokeInvitation())
+        {
+            permissions.Add("family:revoke-invitation");
+        }
+
+        if (CanRemoveMembers())
+        {
+            permissions.Add("family:remove-members");
+        }
+
+        if (CanEditFamily())
+        {
+            permissions.Add("family:edit");
+        }
+
+        if (CanDeleteFamily())
+        {
+            permissions.Add("family:delete");
+        }
+
+        if (CanManageRoles())
+        {
+            permissions.Add("family:manage-roles");
+        }
+
         return permissions;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/AccessShareLink/AccessShareLinkCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/AccessShareLink/AccessShareLinkCommandHandler.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.Events;
 using FamilyHub.Api.Features.FileManagement.Domain.Repositories;
 using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Application;
@@ -20,25 +19,37 @@ public sealed class AccessShareLinkCommandHandler(
             ?? throw new DomainException("Share link not found", DomainErrorCodes.ShareLinkNotFound);
 
         if (link.IsRevoked)
+        {
             throw new DomainException("Share link has been revoked", DomainErrorCodes.ShareLinkRevoked);
+        }
 
         if (link.IsExpired)
+        {
             throw new DomainException("Share link has expired", DomainErrorCodes.ShareLinkExpired);
+        }
 
         if (link.IsDownloadLimitReached)
+        {
             throw new DomainException("Download limit reached", DomainErrorCodes.ShareLinkDownloadLimitReached);
+        }
 
         if (link.HasPassword)
         {
             if (string.IsNullOrEmpty(command.Password))
+            {
                 throw new DomainException("Password required", DomainErrorCodes.ShareLinkPasswordRequired);
+            }
 
             if (!BCrypt.Net.BCrypt.Verify(command.Password, link.PasswordHash))
+            {
                 throw new DomainException("Incorrect password", DomainErrorCodes.ShareLinkPasswordIncorrect);
+            }
         }
 
         if (command.Action == ShareAccessAction.Download)
+        {
             link.IncrementDownloadCount();
+        }
 
         var accessLog = ShareLinkAccessLog.Create(
             link.Id,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/AddFileToAlbum/AddFileToAlbumCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/AddFileToAlbum/AddFileToAlbumCommandHandler.cs
@@ -19,25 +19,33 @@ public sealed class AddFileToAlbumCommandHandler(
             ?? throw new DomainException("Album not found", DomainErrorCodes.AlbumNotFound);
 
         if (album.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Album belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         var file = await storedFileRepository.GetByIdAsync(command.FileId, cancellationToken)
-            ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
+                   ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != command.FamilyId)
+        {
             throw new DomainException("File belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         // Idempotent: if already in album, return success
         var exists = await albumItemRepository.ExistsAsync(command.AlbumId, command.FileId, cancellationToken);
         if (exists)
+        {
             return new AddFileToAlbumResult(true);
+        }
 
         var item = AlbumItem.Create(command.AlbumId, command.FileId, command.AddedBy);
         await albumItemRepository.AddAsync(item, cancellationToken);
 
         // Auto-set cover image if not set
         if (album.CoverFileId is null)
+        {
             album.SetCoverImage(command.FileId);
+        }
 
         return new AddFileToAlbumResult(true);
     }

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ConnectExternalStorage/ConnectExternalStorageCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ConnectExternalStorage/ConnectExternalStorageCommandHandler.cs
@@ -17,9 +17,11 @@ public sealed class ConnectExternalStorageCommandHandler(
             command.FamilyId, command.ProviderType, cancellationToken);
 
         if (existing is not null)
+        {
             throw new DomainException(
                 "Connection to this provider already exists",
                 DomainErrorCodes.ExternalConnectionAlreadyExists);
+        }
 
         var connection = ExternalConnection.Create(
             command.FamilyId,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/CreateZipJob/CreateZipJobCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/CreateZipJob/CreateZipJobCommandHandler.cs
@@ -17,17 +17,21 @@ public sealed class CreateZipJobCommandHandler(
         CancellationToken cancellationToken)
     {
         if (command.FileIds.Count > MaxFilesPerZip)
+        {
             throw new DomainException(
                 $"Cannot zip more than {MaxFilesPerZip} files at once",
                 DomainErrorCodes.ZipJobTooManyFiles);
+        }
 
         var activeJobs = await zipJobRepository.GetActiveJobCountAsync(
             command.FamilyId, cancellationToken);
 
         if (activeJobs >= MaxConcurrentJobs)
+        {
             throw new DomainException(
                 $"Maximum of {MaxConcurrentJobs} concurrent zip jobs per family",
                 DomainErrorCodes.ZipJobConcurrentLimitReached);
+        }
 
         var job = ZipJob.Create(command.FamilyId, command.InitiatedBy, command.FileIds);
         await zipJobRepository.AddAsync(job, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteAlbum/DeleteAlbumCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteAlbum/DeleteAlbumCommandHandler.cs
@@ -17,7 +17,9 @@ public sealed class DeleteAlbumCommandHandler(
             ?? throw new DomainException("Album not found", DomainErrorCodes.AlbumNotFound);
 
         if (album.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Album belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         // Remove all album items first
         await albumItemRepository.RemoveByAlbumIdAsync(command.AlbumId, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteOrganizationRule/DeleteOrganizationRuleCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteOrganizationRule/DeleteOrganizationRuleCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class DeleteOrganizationRuleCommandHandler(
             ?? throw new DomainException("Organization rule not found", DomainErrorCodes.OrganizationRuleNotFound);
 
         if (rule.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Cannot delete rule from another family", DomainErrorCodes.Forbidden);
+        }
 
         await ruleRepository.RemoveAsync(rule, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteSavedSearch/DeleteSavedSearchCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteSavedSearch/DeleteSavedSearchCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class DeleteSavedSearchCommandHandler(
             ?? throw new DomainException("Saved search not found", DomainErrorCodes.NotFound);
 
         if (search.UserId != command.UserId)
+        {
             throw new DomainException("Cannot delete another user's saved search", DomainErrorCodes.Forbidden);
+        }
 
         await savedSearchRepository.RemoveAsync(search, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteSecureNote/DeleteSecureNoteCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DeleteSecureNote/DeleteSecureNoteCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class DeleteSecureNoteCommandHandler(
             ?? throw new DomainException("Secure note not found", DomainErrorCodes.SecureNoteNotFound);
 
         if (note.UserId != command.UserId)
+        {
             throw new DomainException("Secure note not found", DomainErrorCodes.SecureNoteNotFound);
+        }
 
         note.MarkDeleted();
         await noteRepository.RemoveAsync(note, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DisconnectExternalStorage/DisconnectExternalStorageCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/DisconnectExternalStorage/DisconnectExternalStorageCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class DisconnectExternalStorageCommandHandler(
             ?? throw new DomainException("External connection not found", DomainErrorCodes.ExternalConnectionNotFound);
 
         if (connection.FamilyId != command.FamilyId)
+        {
             throw new DomainException("External connection not found", DomainErrorCodes.ExternalConnectionNotFound);
+        }
 
         connection.Disconnect();
         await connectionRepository.RemoveAsync(connection, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/GenerateThumbnails/GenerateThumbnailsCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/GenerateThumbnails/GenerateThumbnailsCommandHandler.cs
@@ -29,21 +29,29 @@ public sealed class GenerateThumbnailsCommandHandler(
             ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != command.FamilyId)
+        {
             throw new DomainException("File not found in this family", DomainErrorCodes.FileNotFound);
+        }
 
         if (!thumbnailService.CanGenerateThumbnail(file.MimeType.Value))
+        {
             return new GenerateThumbnailsResult(true, 0);
+        }
 
         await using var sourceStream = await storageProvider.DownloadAsync(file.StorageKey.Value, cancellationToken);
         if (sourceStream is null)
+        {
             return new GenerateThumbnailsResult(false, 0);
+        }
 
         using var memoryStream = new MemoryStream();
         await sourceStream.CopyToAsync(memoryStream, cancellationToken);
         var sourceData = memoryStream.ToArray();
 
         if (sourceData.Length == 0)
+        {
             return new GenerateThumbnailsResult(false, 0);
+        }
 
         var generated = 0;
         foreach (var (width, height) in ThumbnailSizes)
@@ -51,7 +59,9 @@ public sealed class GenerateThumbnailsCommandHandler(
             var existing = await thumbnailRepository.GetByFileIdAndSizeAsync(
                 command.FileId, width, height, cancellationToken);
             if (existing is not null)
+            {
                 continue;
+            }
 
             var thumbnailData = await thumbnailService.GenerateThumbnailAsync(
                 sourceData, file.MimeType.Value, width, height, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ProcessInboxFiles/ProcessInboxFilesCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ProcessInboxFiles/ProcessInboxFilesCommandHandler.cs
@@ -55,7 +55,9 @@ public sealed class ProcessInboxFilesCommandHandler(
         }
 
         if (logEntries.Count > 0)
+        {
             await logRepository.AddRangeAsync(logEntries, cancellationToken);
+        }
 
         return new ProcessInboxFilesResult(
             true,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RemoveFileFromAlbum/RemoveFileFromAlbumCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RemoveFileFromAlbum/RemoveFileFromAlbumCommandHandler.cs
@@ -17,13 +17,17 @@ public sealed class RemoveFileFromAlbumCommandHandler(
             ?? throw new DomainException("Album not found", DomainErrorCodes.AlbumNotFound);
 
         if (album.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Album belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         var items = await albumItemRepository.GetByAlbumIdAsync(command.AlbumId, cancellationToken);
         var item = items.FirstOrDefault(ai => ai.FileId == command.FileId);
 
         if (item is null)
+        {
             return new RemoveFileFromAlbumResult(true); // Idempotent
+        }
 
         await albumItemRepository.RemoveAsync(item, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RemovePermission/RemovePermissionCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RemovePermission/RemovePermissionCommandHandler.cs
@@ -17,7 +17,9 @@ public sealed class RemovePermissionCommandHandler(
             ?? throw new DomainException("Permission not found", DomainErrorCodes.NotFound);
 
         if (permission.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Permission belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         await permissionRepository.RemoveAsync(permission, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RenameAlbum/RenameAlbumCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RenameAlbum/RenameAlbumCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class RenameAlbumCommandHandler(
             ?? throw new DomainException("Album not found", DomainErrorCodes.AlbumNotFound);
 
         if (album.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Album belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         album.Rename(command.NewName);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RestoreFileVersion/RestoreFileVersionCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RestoreFileVersion/RestoreFileVersionCommandHandler.cs
@@ -2,7 +2,6 @@ using FamilyHub.Api.Features.FileManagement.Domain.Entities;
 using FamilyHub.Api.Features.FileManagement.Domain.Repositories;
 using FamilyHub.Common.Application;
 using FamilyHub.Common.Domain;
-using FamilyHub.Common.Domain.ValueObjects;
 
 namespace FamilyHub.Api.Features.FileManagement.Application.Commands.RestoreFileVersion;
 
@@ -22,7 +21,9 @@ public sealed class RestoreFileVersionCommandHandler(
             ?? throw new DomainException("Version not found", DomainErrorCodes.FileVersionNotFound);
 
         if (sourceVersion.FileId != command.FileId)
+        {
             throw new DomainException("Version does not belong to this file", DomainErrorCodes.FileVersionNotFound);
+        }
 
         // Mark current version as not current
         var currentVersion = await versionRepository.GetCurrentVersionAsync(command.FileId, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RevokeShareLink/RevokeShareLinkCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/RevokeShareLink/RevokeShareLinkCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class RevokeShareLinkCommandHandler(
             ?? throw new DomainException("Share link not found", DomainErrorCodes.ShareLinkNotFound);
 
         if (link.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Share link not found", DomainErrorCodes.ShareLinkNotFound);
+        }
 
         link.Revoke(command.RevokedBy);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/SetPermission/MutationType.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/SetPermission/MutationType.cs
@@ -40,7 +40,9 @@ public class MutationType
 
         var permissionLevel = (FilePermissionLevel)input.PermissionLevel;
         if (!Enum.IsDefined(permissionLevel))
+        {
             throw new ArgumentException($"Invalid permission level: {input.PermissionLevel}");
+        }
 
         var command = new SetPermissionCommand(
             resourceType,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/SetPermission/SetPermissionCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/SetPermission/SetPermissionCommandHandler.cs
@@ -25,7 +25,9 @@ public sealed class SetPermissionCommandHandler(
                 ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
             if (file.FamilyId != command.FamilyId)
+            {
                 throw new DomainException("File belongs to a different family", DomainErrorCodes.Forbidden);
+            }
         }
         else
         {
@@ -34,7 +36,9 @@ public sealed class SetPermissionCommandHandler(
                 ?? throw new DomainException("Folder not found", DomainErrorCodes.FolderNotFound);
 
             if (folder.FamilyId != command.FamilyId)
+            {
                 throw new DomainException("Folder belongs to a different family", DomainErrorCodes.Forbidden);
+            }
         }
 
         // Check for existing permission — update or create

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/TagFile/TagFileCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/TagFile/TagFileCommandHandler.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.Events;
 using FamilyHub.Api.Features.FileManagement.Domain.Repositories;
 using FamilyHub.Common.Application;
 using FamilyHub.Common.Domain;

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ToggleFavorite/ToggleFavoriteCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ToggleFavorite/ToggleFavoriteCommandHandler.cs
@@ -18,7 +18,9 @@ public sealed class ToggleFavoriteCommandHandler(
             ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != command.FamilyId)
+        {
             throw new DomainException("File belongs to a different family", DomainErrorCodes.Forbidden);
+        }
 
         var isFavorited = await userFavoriteRepository.ExistsAsync(command.UserId, command.FileId, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ToggleOrganizationRule/ToggleOrganizationRuleCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/ToggleOrganizationRule/ToggleOrganizationRuleCommandHandler.cs
@@ -16,12 +16,18 @@ public sealed class ToggleOrganizationRuleCommandHandler(
             ?? throw new DomainException("Organization rule not found", DomainErrorCodes.OrganizationRuleNotFound);
 
         if (rule.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Cannot modify rule from another family", DomainErrorCodes.Forbidden);
+        }
 
         if (command.IsEnabled)
+        {
             rule.Enable();
+        }
         else
+        {
             rule.Disable();
+        }
 
         return new ToggleOrganizationRuleResult(true);
     }

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/UpdateOrganizationRule/UpdateOrganizationRuleCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/UpdateOrganizationRule/UpdateOrganizationRuleCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class UpdateOrganizationRuleCommandHandler(
             ?? throw new DomainException("Organization rule not found", DomainErrorCodes.OrganizationRuleNotFound);
 
         if (rule.FamilyId != command.FamilyId)
+        {
             throw new DomainException("Cannot modify rule from another family", DomainErrorCodes.Forbidden);
+        }
 
         rule.Update(
             command.Name,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Commands/UpdateSecureNote/UpdateSecureNoteCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Commands/UpdateSecureNote/UpdateSecureNoteCommandHandler.cs
@@ -16,7 +16,9 @@ public sealed class UpdateSecureNoteCommandHandler(
             ?? throw new DomainException("Secure note not found", DomainErrorCodes.SecureNoteNotFound);
 
         if (note.UserId != command.UserId)
+        {
             throw new DomainException("Secure note not found", DomainErrorCodes.SecureNoteNotFound);
+        }
 
         note.Update(
             command.Category,

--- a/src/FamilyHub.Api/Features/FileManagement/Application/EventHandlers/FamilyCreatedEventHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/EventHandlers/FamilyCreatedEventHandler.cs
@@ -24,13 +24,17 @@ public sealed class FamilyCreatedEventHandler(
         {
             var existingInbox = await folderRepository.GetInboxFolderAsync(@event.FamilyId, cancellationToken);
             if (existingInbox is not null)
+            {
                 return;
+            }
         }
 
         // Create root folder if needed
         var root = existingRoot ?? Folder.CreateRoot(@event.FamilyId, @event.OwnerId);
         if (existingRoot is null)
+        {
             await folderRepository.AddAsync(root, cancellationToken);
+        }
 
         // Create inbox folder
         var inbox = Folder.CreateInbox(root.Id, @event.FamilyId, @event.OwnerId);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFavorites/GetFavoritesQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFavorites/GetFavoritesQueryHandler.cs
@@ -17,7 +17,9 @@ public sealed class GetFavoritesQueryHandler(
         var favorites = await userFavoriteRepository.GetByUserIdAsync(query.UserId, cancellationToken);
 
         if (favorites.Count == 0)
+        {
             return [];
+        }
 
         var fileIds = favorites.Select(f => f.FileId).ToList();
         var files = await storedFileRepository.GetByIdsAsync(fileIds, cancellationToken);

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFileVersions/GetFileVersionsQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFileVersions/GetFileVersionsQueryHandler.cs
@@ -3,7 +3,6 @@ using FamilyHub.Api.Features.FileManagement.Domain.Repositories;
 using FamilyHub.Api.Features.FileManagement.Models;
 using FamilyHub.Common.Application;
 using FamilyHub.Common.Domain;
-using FamilyHub.Common.Domain.ValueObjects;
 
 namespace FamilyHub.Api.Features.FileManagement.Application.Queries.GetFileVersions;
 
@@ -20,7 +19,9 @@ public sealed class GetFileVersionsQueryHandler(
             ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != query.FamilyId)
+        {
             throw new DomainException("File not found in this family", DomainErrorCodes.FileNotFound);
+        }
 
         var versions = await versionRepository.GetByFileIdAsync(query.FileId, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFiles/QueryType.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFiles/QueryType.cs
@@ -48,7 +48,9 @@ public class QueryType
         CancellationToken cancellationToken)
     {
         if (folderId.HasValue && folderId.Value != Guid.Empty)
+        {
             return FolderId.From(folderId.Value);
+        }
 
         var rootFolder = await folderRepository.GetRootFolderAsync(familyId, cancellationToken);
         if (rootFolder is null)

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFilesByTag/GetFilesByTagQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFilesByTag/GetFilesByTagQueryHandler.cs
@@ -15,13 +15,17 @@ public sealed class GetFilesByTagQueryHandler(
         CancellationToken cancellationToken)
     {
         if (query.TagIds.Count == 0)
+        {
             return [];
+        }
 
         // Get file IDs that have ALL specified tags (AND logic)
         var fileIds = await fileTagRepository.GetFileIdsByTagIdsAsync(query.TagIds, cancellationToken);
 
         if (fileIds.Count == 0)
+        {
             return [];
+        }
 
         var files = await storedFileRepository.GetByIdsAsync(fileIds, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFolders/QueryType.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetFolders/QueryType.cs
@@ -48,7 +48,9 @@ public class QueryType
         CancellationToken cancellationToken)
     {
         if (parentFolderId.HasValue && parentFolderId.Value != Guid.Empty)
+        {
             return FolderId.From(parentFolderId.Value);
+        }
 
         var rootFolder = await folderRepository.GetRootFolderAsync(familyId, cancellationToken);
         if (rootFolder is null)

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetMediaStreamInfo/GetMediaStreamInfoQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetMediaStreamInfo/GetMediaStreamInfoQueryHandler.cs
@@ -27,7 +27,9 @@ public sealed class GetMediaStreamInfoQueryHandler(
             ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != query.FamilyId)
+        {
             throw new DomainException("File not found in this family", DomainErrorCodes.FileNotFound);
+        }
 
         var thumbnails = await thumbnailRepository.GetByFileIdAsync(query.FileId, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetShareLinkAccessLog/GetShareLinkAccessLogQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/GetShareLinkAccessLog/GetShareLinkAccessLogQueryHandler.cs
@@ -19,7 +19,9 @@ public sealed class GetShareLinkAccessLogQueryHandler(
             ?? throw new DomainException("Share link not found", DomainErrorCodes.ShareLinkNotFound);
 
         if (link.FamilyId != query.FamilyId)
+        {
             throw new DomainException("Share link not found", DomainErrorCodes.ShareLinkNotFound);
+        }
 
         var logs = await accessLogRepository.GetByShareLinkIdAsync(query.ShareLinkId, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Queries/PreviewRuleMatch/PreviewRuleMatchQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Queries/PreviewRuleMatch/PreviewRuleMatchQueryHandler.cs
@@ -20,7 +20,9 @@ public sealed class PreviewRuleMatchQueryHandler(
             ?? throw new DomainException("File not found", DomainErrorCodes.FileNotFound);
 
         if (file.FamilyId != query.FamilyId)
+        {
             throw new DomainException("File does not belong to this family", DomainErrorCodes.Forbidden);
+        }
 
         var rules = await ruleRepository.GetEnabledByFamilyIdAsync(query.FamilyId, cancellationToken);
 

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Search/FileManagementSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Search/FileManagementSearchProvider.cs
@@ -18,7 +18,9 @@ public sealed class FileManagementSearchProvider(
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null || string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         var queryLower = context.Query.ToLowerInvariant();
         var isGerman = context.Locale?.StartsWith("de", StringComparison.OrdinalIgnoreCase) == true;

--- a/src/FamilyHub.Api/Features/FileManagement/Application/Services/IThumbnailGenerationService.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Application/Services/IThumbnailGenerationService.cs
@@ -1,5 +1,3 @@
-using FamilyHub.Common.Domain.ValueObjects;
-
 namespace FamilyHub.Api.Features.FileManagement.Application.Services;
 
 /// <summary>

--- a/src/FamilyHub.Api/Features/FileManagement/Data/ExternalConnectionConfiguration.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Data/ExternalConnectionConfiguration.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/FamilyHub.Api/Features/FileManagement/Data/SecureNoteConfiguration.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Data/SecureNoteConfiguration.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/Entities/ZipJob.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/Entities/ZipJob.cs
@@ -23,7 +23,9 @@ public sealed class ZipJob : AggregateRoot<ZipJobId>
         TimeSpan ttl = default)
     {
         if (ttl == default)
+        {
             ttl = TimeSpan.FromHours(24);
+        }
 
         var job = new ZipJob
         {

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/AlbumName.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/AlbumName.cs
@@ -8,9 +8,15 @@ public readonly partial struct AlbumName
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Album name cannot be empty.");
+        }
+
         if (value.Length > 100)
+        {
             return Validation.Invalid("Album name cannot exceed 100 characters.");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/Checksum.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/Checksum.cs
@@ -11,11 +11,20 @@ public readonly partial struct Checksum
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Checksum cannot be empty");
+        }
+
         if (value.Length != 64)
+        {
             return Validation.Invalid("SHA-256 checksum must be 64 hex characters");
+        }
+
         if (!value.All(c => char.IsAsciiHexDigitLower(c) || char.IsAsciiDigit(c)))
+        {
             return Validation.Invalid("Checksum must contain only lowercase hex characters");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/FileName.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/FileName.cs
@@ -11,13 +11,25 @@ public readonly partial struct FileName
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("File name cannot be empty");
+        }
+
         if (value.Length > 255)
+        {
             return Validation.Invalid("File name too long (max 255 characters)");
+        }
+
         if (value.Contains('/') || value.Contains('\\'))
+        {
             return Validation.Invalid("File name cannot contain path separators");
+        }
+
         if (value.Contains('\0'))
+        {
             return Validation.Invalid("File name cannot contain null bytes");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/FileSize.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/FileSize.cs
@@ -11,7 +11,10 @@ public readonly partial struct FileSize
     private static Validation Validate(long value)
     {
         if (value < 0)
+        {
             return Validation.Invalid("File size cannot be negative");
+        }
+
         return Validation.Ok;
     }
 

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/GpsCoordinate.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/GpsCoordinate.cs
@@ -8,7 +8,10 @@ public readonly partial struct Latitude
     private static Validation Validate(double value)
     {
         if (value is < -90 or > 90)
+        {
             return Validation.Invalid("Latitude must be between -90 and 90");
+        }
+
         return Validation.Ok;
     }
 }
@@ -19,7 +22,10 @@ public readonly partial struct Longitude
     private static Validation Validate(double value)
     {
         if (value is < -180 or > 180)
+        {
             return Validation.Invalid("Longitude must be between -180 and 180");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/MimeType.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/MimeType.cs
@@ -13,11 +13,20 @@ public readonly partial struct MimeType
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("MIME type cannot be empty");
+        }
+
         if (value.Length > 255)
+        {
             return Validation.Invalid("MIME type too long (max 255 characters)");
+        }
+
         if (!value.Contains('/'))
+        {
             return Validation.Invalid("MIME type must contain a '/' separator");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/StorageKey.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/StorageKey.cs
@@ -13,9 +13,15 @@ public readonly partial struct StorageKey
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Storage key cannot be empty");
+        }
+
         if (value.Length > 255)
+        {
             return Validation.Invalid("Storage key too long (max 255 characters)");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/TagColor.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/TagColor.cs
@@ -11,9 +11,15 @@ public readonly partial struct TagColor
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Tag color cannot be empty");
+        }
+
         if (!HexColorPattern.IsMatch(value))
+        {
             return Validation.Invalid("Tag color must be a valid hex color (e.g., #FF5733)");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/TagName.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Domain/ValueObjects/TagName.cs
@@ -8,9 +8,15 @@ public readonly partial struct TagName
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Tag name cannot be empty");
+        }
+
         if (value.Length > 50)
+        {
             return Validation.Invalid("Tag name too long (max 50 characters)");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/FilePermissionConfiguration.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/FilePermissionConfiguration.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/OrganizationRuleConfiguration.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/OrganizationRuleConfiguration.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/ProcessingLogEntryConfiguration.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Data/ProcessingLogEntryConfiguration.cs
@@ -1,5 +1,4 @@
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Endpoints/FileEndpoints.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Endpoints/FileEndpoints.cs
@@ -4,7 +4,6 @@ using FamilyHub.Api.Features.Auth.Domain.Repositories;
 using FamilyHub.Api.Features.FileManagement.Infrastructure.Storage;
 using FamilyHub.Common.Domain.ValueObjects;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 
 namespace FamilyHub.Api.Features.FileManagement.Infrastructure.Endpoints;
 
@@ -42,12 +41,16 @@ public static class FileEndpoints
     {
         var familyId = await GetFamilyIdAsync(httpContext.User, userRepository, ct);
         if (familyId is null)
+        {
             return Results.Unauthorized();
+        }
 
         var form = await httpContext.Request.ReadFormAsync(ct);
         var file = form.Files.FirstOrDefault();
         if (file is null || file.Length == 0)
+        {
             return Results.BadRequest(new { error = "No file provided" });
+        }
 
         using var stream = file.OpenReadStream();
         var result = await storageService.StoreFileAsync(familyId.Value, stream, file.FileName, ct);
@@ -68,7 +71,9 @@ public static class FileEndpoints
     {
         var result = await storageService.GetFileAsync(storageKey, ct);
         if (result is null)
+        {
             return Results.NotFound();
+        }
 
         return Results.File(result.Data, result.MimeType);
     }
@@ -86,7 +91,9 @@ public static class FileEndpoints
             // No range requested — return full file
             var result = await storageService.GetFileAsync(storageKey, ct);
             if (result is null)
+            {
                 return Results.NotFound();
+            }
 
             httpContext.Response.Headers["Accept-Ranges"] = "bytes";
             return Results.File(result.Data, result.MimeType);
@@ -95,12 +102,16 @@ public static class FileEndpoints
         // Parse "bytes=start-end"
         var (from, to) = ParseRangeHeader(rangeHeader);
         if (from is null)
+        {
             return Results.BadRequest(new { error = "Invalid range header" });
+        }
 
         var rangeResult = await storageService.GetFileRangeAsync(
             storageKey, from.Value, to ?? long.MaxValue, ct);
         if (rangeResult is null)
+        {
             return Results.NotFound();
+        }
 
         httpContext.Response.StatusCode = 206;
         httpContext.Response.Headers["Accept-Ranges"] = "bytes";
@@ -120,7 +131,9 @@ public static class FileEndpoints
     {
         var familyId = await GetFamilyIdAsync(httpContext.User, userRepository, ct);
         if (familyId is null)
+        {
             return Results.Unauthorized();
+        }
 
         var uploadId = await storageService.InitiateChunkedUploadAsync(ct);
         return Results.Ok(new { uploadId });
@@ -136,7 +149,9 @@ public static class FileEndpoints
         var form = await httpContext.Request.ReadFormAsync(ct);
         var file = form.Files.FirstOrDefault();
         if (file is null || file.Length == 0)
+        {
             return Results.BadRequest(new { error = "No chunk data provided" });
+        }
 
         using var stream = file.OpenReadStream();
         await storageService.UploadChunkAsync(uploadId, chunkIndex, stream, ct);
@@ -154,7 +169,9 @@ public static class FileEndpoints
     {
         var familyId = await GetFamilyIdAsync(httpContext.User, userRepository, ct);
         if (familyId is null)
+        {
             return Results.Unauthorized();
+        }
 
         var result = await storageService.CompleteChunkedUploadAsync(
             familyId.Value, uploadId, request.FileName, ct);
@@ -172,7 +189,10 @@ public static class FileEndpoints
         ClaimsPrincipal user, IUserRepository userRepository, CancellationToken ct)
     {
         var externalUserId = user.FindFirst(ClaimNames.Sub)?.Value;
-        if (externalUserId is null) return null;
+        if (externalUserId is null)
+        {
+            return null;
+        }
 
         var userEntity = await userRepository.GetByExternalIdAsync(
             ExternalUserId.From(externalUserId), ct);
@@ -183,14 +203,21 @@ public static class FileEndpoints
     {
         // Format: "bytes=start-end" or "bytes=start-"
         if (!rangeHeader.StartsWith("bytes=", StringComparison.OrdinalIgnoreCase))
+        {
             return (null, null);
+        }
 
         var range = rangeHeader["bytes=".Length..];
         var parts = range.Split('-');
-        if (parts.Length != 2) return (null, null);
+        if (parts.Length != 2)
+        {
+            return (null, null);
+        }
 
         if (!long.TryParse(parts[0], out var from))
+        {
             return (null, null);
+        }
 
         long? to = string.IsNullOrEmpty(parts[1]) ? null : long.Parse(parts[1]);
         return (from, to);

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Repositories/FolderRepository.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Repositories/FolderRepository.cs
@@ -35,7 +35,9 @@ public sealed class FolderRepository(AppDbContext context) : IFolderRepository
     {
         var folder = await context.Set<Folder>().FindAsync([folderId], cancellationToken: ct);
         if (folder is null)
+        {
             return [];
+        }
 
         // Parse folder IDs from materialized path (e.g., "/id1/id2/" → [id1, id2])
         var pathSegments = folder.MaterializedPath
@@ -46,7 +48,9 @@ public sealed class FolderRepository(AppDbContext context) : IFolderRepository
             .ToList();
 
         if (pathSegments.Count == 0)
+        {
             return [];
+        }
 
         var ancestors = await context.Set<Folder>()
             .Where(f => pathSegments.Contains(f.Id))
@@ -69,7 +73,9 @@ public sealed class FolderRepository(AppDbContext context) : IFolderRepository
             .ToListAsync(ct);
 
         if (descendantFolderIds.Count == 0)
+        {
             return 0;
+        }
 
         return await context.Set<StoredFile>()
             .Where(f => descendantFolderIds.Contains(f.FolderId))

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Repositories/RecentSearchRepository.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Repositories/RecentSearchRepository.cs
@@ -27,6 +27,8 @@ public sealed class RecentSearchRepository(AppDbContext context) : IRecentSearch
             .ToListAsync(ct);
 
         if (toRemove.Count > 0)
+        {
             context.Set<RecentSearch>().RemoveRange(toRemove);
+        }
     }
 }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/FileManagementAuthorizationService.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/FileManagementAuthorizationService.cs
@@ -24,12 +24,16 @@ public sealed class FileManagementAuthorizationService(
     {
         // 1. Family Owner/Admin bypass
         if (await IsFamilyAdminOrOwnerAsync(userId, familyId, ct))
+        {
             return true;
+        }
 
         // 2. File owner always has Manage
         var file = await storedFileRepository.GetByIdAsync(fileId, ct);
         if (file is not null && file.UploadedBy == userId)
+        {
             return true;
+        }
 
         // 3. Check if the file has any direct permissions (is it restricted?)
         var fileRestricted = await permissionRepository.HasAnyPermissionsAsync(
@@ -42,7 +46,9 @@ public sealed class FileManagementAuthorizationService(
                 userId, PermissionResourceType.File, fileId.Value, ct);
 
             if (directPerm is not null)
+            {
                 return directPerm.PermissionLevel >= requiredLevel;
+            }
 
             // Direct restriction exists but user has no grant — denied at file level
             // Still check folder inheritance below
@@ -55,7 +61,9 @@ public sealed class FileManagementAuthorizationService(
                 userId, file.FolderId, requiredLevel, ct);
 
             if (hasInherited.HasValue)
+            {
                 return hasInherited.Value;
+            }
         }
 
         // 5. No restrictions found anywhere → default unrestricted
@@ -68,12 +76,16 @@ public sealed class FileManagementAuthorizationService(
     {
         // 1. Family Owner/Admin bypass
         if (await IsFamilyAdminOrOwnerAsync(userId, familyId, ct))
+        {
             return true;
+        }
 
         // 2. Folder creator always has Manage
         var folder = await folderRepository.GetByIdAsync(folderId, ct);
         if (folder is not null && folder.CreatedBy == userId)
+        {
             return true;
+        }
 
         // 3. Check direct folder permission
         var folderRestricted = await permissionRepository.HasAnyPermissionsAsync(
@@ -85,7 +97,9 @@ public sealed class FileManagementAuthorizationService(
                 userId, PermissionResourceType.Folder, folderId.Value, ct);
 
             if (directPerm is not null)
+            {
                 return directPerm.PermissionLevel >= requiredLevel;
+            }
         }
 
         // 4. Walk up parent folders
@@ -95,7 +109,9 @@ public sealed class FileManagementAuthorizationService(
                 userId, folder.ParentFolderId.Value, requiredLevel, ct);
 
             if (hasInherited.HasValue)
+            {
                 return hasInherited.Value;
+            }
         }
 
         // 5. No restrictions found → default unrestricted
@@ -124,7 +140,9 @@ public sealed class FileManagementAuthorizationService(
         var folderChain = new List<FolderId>();
 
         if (startFolder is not null)
+        {
             folderChain.Add(startFolder.Id);
+        }
 
         folderChain.AddRange(ancestors.Select(a => a.Id));
 
@@ -135,7 +153,9 @@ public sealed class FileManagementAuthorizationService(
                 PermissionResourceType.Folder, folderId.Value, ct);
 
             if (!hasPermissions)
+            {
                 continue;
+            }
 
             // This folder is restricted — check user's grant
             var perm = await permissionRepository.GetByMemberAndResourceAsync(

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/FileSearchService.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/FileSearchService.cs
@@ -41,16 +41,24 @@ public sealed class FileSearchService(
         if (filters is not null)
         {
             if (filters.MimeTypes is { Count: > 0 })
+            {
                 matched = matched.Where(f => filters.MimeTypes.Contains(f.MimeType.Value)).ToList();
+            }
 
             if (filters.DateFrom.HasValue)
+            {
                 matched = matched.Where(f => f.CreatedAt >= filters.DateFrom.Value).ToList();
+            }
 
             if (filters.DateTo.HasValue)
+            {
                 matched = matched.Where(f => f.CreatedAt <= filters.DateTo.Value).ToList();
+            }
 
             if (filters.FolderId.HasValue)
+            {
                 matched = matched.Where(f => f.FolderId.Value == filters.FolderId.Value).ToList();
+            }
 
             if (filters.TagIds is { Count: > 0 })
             {
@@ -59,7 +67,7 @@ public sealed class FileSearchService(
                 matched = matched.Where(f => fileIdsWithTags.Contains(f.Id)).ToList();
             }
 
-            if (filters.GpsLatitude.HasValue && filters.GpsLongitude.HasValue && filters.GpsRadiusKm.HasValue)
+            if (filters is { GpsLatitude: not null, GpsLongitude: not null, GpsRadiusKm: not null })
             {
                 var filesWithGps = new List<Domain.Entities.StoredFile>();
                 foreach (var file in matched)
@@ -72,7 +80,9 @@ public sealed class FileSearchService(
                             (double)metadata.GpsLatitude.Value.Value, (double)metadata.GpsLongitude.Value.Value);
 
                         if (distance <= filters.GpsRadiusKm.Value)
+                        {
                             filesWithGps.Add(file);
+                        }
                     }
                 }
                 matched = filesWithGps;
@@ -110,7 +120,10 @@ public sealed class FileSearchService(
     private static string HighlightMatch(string text, string query)
     {
         var idx = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
-        if (idx < 0) return text;
+        if (idx < 0)
+        {
+            return text;
+        }
 
         var before = text[..idx];
         var match = text.Substring(idx, query.Length);
@@ -120,9 +133,21 @@ public sealed class FileSearchService(
 
     private static double CalculateRelevance(string text, string query)
     {
-        if (text.Equals(query, StringComparison.OrdinalIgnoreCase)) return 1.0;
-        if (text.StartsWith(query, StringComparison.OrdinalIgnoreCase)) return 0.8;
-        if (text.Contains(query, StringComparison.OrdinalIgnoreCase)) return 0.5;
+        if (text.Equals(query, StringComparison.OrdinalIgnoreCase))
+        {
+            return 1.0;
+        }
+
+        if (text.StartsWith(query, StringComparison.OrdinalIgnoreCase))
+        {
+            return 0.8;
+        }
+
+        if (text.Contains(query, StringComparison.OrdinalIgnoreCase))
+        {
+            return 0.5;
+        }
+
         return 0.0;
     }
 

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/MetadataExtractionService.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/MetadataExtractionService.cs
@@ -21,7 +21,9 @@ public sealed class MetadataExtractionService : IMetadataExtractionService
     public Task<ExtractionResult?> ExtractAsync(Stream data, string mimeType, CancellationToken ct = default)
     {
         if (!SupportedMimeTypes.Contains(mimeType.ToLowerInvariant()))
+        {
             return Task.FromResult<ExtractionResult?>(null);
+        }
 
         try
         {
@@ -73,7 +75,9 @@ public sealed class MetadataExtractionService : IMetadataExtractionService
                 }
 
                 if (tags.Count > 0)
+                {
                     rawExif[directory.Name] = tags;
+                }
             }
 
             var rawExifJson = rawExif.Count > 0
@@ -84,7 +88,9 @@ public sealed class MetadataExtractionService : IMetadataExtractionService
 
             // Only return result if at least some metadata was extracted
             if (latitude is null && longitude is null && cameraModel is null && captureDate is null && rawExifJson is null)
+            {
                 return Task.FromResult<ExtractionResult?>(null);
+            }
 
             return Task.FromResult<ExtractionResult?>(result);
         }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/OrganizationRuleEngine.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Services/OrganizationRuleEngine.cs
@@ -19,7 +19,9 @@ public sealed class OrganizationRuleEngine : IOrganizationRuleEngine
         foreach (var rule in rules)
         {
             if (!rule.IsEnabled)
+            {
                 continue;
+            }
 
             if (MatchesRule(file, rule))
             {
@@ -49,7 +51,9 @@ public sealed class OrganizationRuleEngine : IOrganizationRuleEngine
         }
 
         if (conditions.Count == 0)
+        {
             return false;
+        }
 
         return rule.ConditionLogic == ConditionLogic.And
             ? conditions.All(c => EvaluateCondition(file, c))
@@ -86,7 +90,10 @@ public sealed class OrganizationRuleEngine : IOrganizationRuleEngine
         return patterns.Any(pattern =>
         {
             if (pattern.EndsWith("/*"))
+            {
                 return mimeType.StartsWith(pattern[..^2], StringComparison.OrdinalIgnoreCase);
+            }
+
             return string.Equals(mimeType, pattern, StringComparison.OrdinalIgnoreCase);
         });
     }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/ChecksumCalculator.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/ChecksumCalculator.cs
@@ -39,7 +39,9 @@ public sealed class ChecksumCalculator : IChecksumCalculator
         var hash = await SHA256.HashDataAsync(data, ct);
 
         if (data.CanSeek)
+        {
             data.Position = startPosition;
+        }
 
         return Convert.ToHexStringLower(hash);
     }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/FileManagementStorageService.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/FileManagementStorageService.cs
@@ -31,12 +31,16 @@ public sealed class FileManagementStorageService(
 
         // Validate file size
         if (bytes.Length > _options.MaxFileSizeBytes)
+        {
             throw new InvalidOperationException(
                 $"File exceeds maximum size of {_options.MaxFileSizeBytes / (1024 * 1024)} MB");
+        }
 
         // Check quota
         if (!await quotaService.CanUploadAsync(familyId, bytes.Length, ct))
+        {
             throw new InvalidOperationException("Storage quota exceeded");
+        }
 
         // Detect MIME type from content (first 512 bytes)
         var headerLength = Math.Min(bytes.Length, 512);
@@ -64,7 +68,10 @@ public sealed class FileManagementStorageService(
     public async Task<FileDownloadResult?> GetFileAsync(string storageKey, CancellationToken ct = default)
     {
         var stream = await storageProvider.DownloadAsync(storageKey, ct);
-        if (stream is null) return null;
+        if (stream is null)
+        {
+            return null;
+        }
 
         var size = await storageProvider.GetSizeAsync(storageKey, ct);
 
@@ -131,7 +138,9 @@ public sealed class FileManagementStorageService(
             .ToListAsync(ct);
 
         if (chunks.Count == 0)
+        {
             throw new InvalidOperationException("No chunks found for upload ID");
+        }
 
         // Assemble chunks into a single stream
         using var assembledStream = new MemoryStream();

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/MimeDetector.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/MimeDetector.cs
@@ -45,7 +45,9 @@ public sealed class MimeDetector : IMimeDetector
     public string Detect(ReadOnlySpan<byte> header, string? fileNameHint = null)
     {
         if (header.Length == 0)
+        {
             return "application/octet-stream";
+        }
 
         // Check magic bytes
         foreach (var (signature, offset, mimeType) in Signatures)
@@ -73,11 +75,19 @@ public sealed class MimeDetector : IMimeDetector
                 {
                     var formatTag = header.Slice(8, 4);
                     if (formatTag.SequenceEqual("WEBP"u8))
+                    {
                         return "image/webp";
+                    }
+
                     if (formatTag.SequenceEqual("AVI "u8))
+                    {
                         return "video/x-msvideo";
+                    }
+
                     if (formatTag.SequenceEqual("WAVE"u8))
+                    {
                         return "audio/wav";
+                    }
                 }
 
                 // Refine MP4 variants (check for ftyp box)
@@ -88,7 +98,10 @@ public sealed class MimeDetector : IMimeDetector
                     {
                         var brand = header.Slice(8, 4);
                         if (brand.SequenceEqual("M4A "u8))
+                        {
                             return "audio/mp4";
+                        }
+
                         return "video/mp4";
                     }
                     // Not actually ftyp — fall through
@@ -130,8 +143,10 @@ public sealed class MimeDetector : IMimeDetector
         {
             var b = data[i];
             // Allow printable ASCII, tabs, newlines, carriage returns, and UTF-8 lead bytes
-            if (b < 0x09 || (b > 0x0D && b < 0x20 && b != 0x1B))
+            if (b < 0x09 || (b is > 0x0D and < 0x20 && b != 0x1B))
+            {
                 return false;
+            }
         }
         return true;
     }

--- a/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/PostgresStorageProvider.cs
+++ b/src/FamilyHub.Api/Features/FileManagement/Infrastructure/Storage/PostgresStorageProvider.cs
@@ -50,7 +50,9 @@ public sealed class PostgresStorageProvider(AppDbContext dbContext) : IStoragePr
             .FirstOrDefaultAsync(f => f.StorageKey == storageKey, ct);
 
         if (blob?.Data is null)
+        {
             return null;
+        }
 
         var totalSize = blob.Data.Length;
         var rangeEnd = Math.Min(to, totalSize - 1);

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Application/Commands/LinkGoogleAccount/LinkGoogleAccountCommandHandler.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Application/Commands/LinkGoogleAccount/LinkGoogleAccountCommandHandler.cs
@@ -38,7 +38,9 @@ public sealed class LinkGoogleAccountCommandHandler(
             command.Code, codeVerifier, cancellationToken);
 
         if (string.IsNullOrEmpty(tokenResponse.RefreshToken))
+        {
             throw new DomainException("Google did not provide a refresh token. Please try linking again.");
+        }
 
         // 3. Get user info from Google
         var userInfo = await oauthService.GetUserInfoAsync(tokenResponse.AccessToken, cancellationToken);
@@ -46,7 +48,9 @@ public sealed class LinkGoogleAccountCommandHandler(
         // 4. Check if user already has a linked account
         var existingLink = await linkRepository.GetByUserIdAsync(userId, cancellationToken);
         if (existingLink is not null)
+        {
             throw new DomainException("A Google account is already linked. Unlink it first.");
+        }
 
         // 5. Encrypt tokens
         var encryptedAccessToken = EncryptedToken.From(

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Controllers/GoogleCallbackController.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Controllers/GoogleCallbackController.cs
@@ -20,10 +20,14 @@ public class GoogleCallbackController(
         var frontendUrl = configuration["App:FrontendUrl"] ?? "http://localhost:4200";
 
         if (!string.IsNullOrEmpty(error))
+        {
             return Redirect($"{frontendUrl}/settings?google_error={Uri.EscapeDataString(error)}");
+        }
 
         if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+        {
             return Redirect($"{frontendUrl}/settings?google_error=missing_parameters");
+        }
 
         try
         {

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/EncryptedToken.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/EncryptedToken.cs
@@ -8,7 +8,10 @@ public readonly partial struct EncryptedToken
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Encrypted token cannot be empty");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleAccountId.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleAccountId.cs
@@ -8,9 +8,15 @@ public readonly partial struct GoogleAccountId
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Google account ID cannot be empty");
+        }
+
         if (value.Length > 255)
+        {
             return Validation.Invalid("Google account ID cannot exceed 255 characters");
+        }
+
         return Validation.Ok;
     }
 

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleAccountLinkId.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleAccountLinkId.cs
@@ -10,7 +10,10 @@ public readonly partial struct GoogleAccountLinkId
     private static Validation Validate(Guid value)
     {
         if (value == Guid.Empty)
+        {
             return Validation.Invalid("Google account link ID cannot be empty");
+        }
+
         return Validation.Ok;
     }
 }

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleLinkStatus.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleLinkStatus.cs
@@ -15,9 +15,15 @@ public readonly partial struct GoogleLinkStatus
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Google link status cannot be empty");
+        }
+
         if (!ValidStatuses.Contains(value))
+        {
             return Validation.Invalid($"Invalid status '{value}'. Valid values: {string.Join(", ", ValidStatuses)}");
+        }
+
         return Validation.Ok;
     }
 

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleScopes.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Domain/ValueObjects/GoogleScopes.cs
@@ -8,7 +8,10 @@ public readonly partial struct GoogleScopes
     private static Validation Validate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
+        {
             return Validation.Invalid("Google scopes cannot be empty");
+        }
+
         return Validation.Ok;
     }
 

--- a/src/FamilyHub.Api/Features/GoogleIntegration/GraphQL/GoogleIntegrationQueries.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/GraphQL/GoogleIntegrationQueries.cs
@@ -26,7 +26,7 @@ public class GoogleIntegrationQueries
             claimsPrincipal, userRepository, cancellationToken);
 
         var query = new GetLinkedAccountsQuery(user.Id);
-        return await queryBus.QueryAsync<List<LinkedAccountDto>>(query, cancellationToken);
+        return await queryBus.QueryAsync(query, cancellationToken);
     }
 
     [Authorize]
@@ -41,7 +41,7 @@ public class GoogleIntegrationQueries
             claimsPrincipal, userRepository, cancellationToken);
 
         var query = new GetCalendarSyncStatusQuery(user.Id);
-        return await queryBus.QueryAsync<GoogleCalendarSyncStatusDto>(query, cancellationToken);
+        return await queryBus.QueryAsync(query, cancellationToken);
     }
 
     [Authorize]
@@ -56,6 +56,6 @@ public class GoogleIntegrationQueries
             claimsPrincipal, userRepository, cancellationToken);
 
         var query = new GetGoogleAuthUrlQuery(user.Id);
-        return await queryBus.QueryAsync<string>(query, cancellationToken);
+        return await queryBus.QueryAsync(query, cancellationToken);
     }
 }

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/AesGcmTokenEncryptionService.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/AesGcmTokenEncryptionService.cs
@@ -15,13 +15,17 @@ public sealed class AesGcmTokenEncryptionService : ITokenEncryptionService
     {
         var keyBase64 = options.Value.EncryptionKey;
         if (string.IsNullOrWhiteSpace(keyBase64))
+        {
             throw new InvalidOperationException(
                 "GoogleIntegration:EncryptionKey must be configured. " +
                 "Generate with: Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))");
+        }
 
         _key = Convert.FromBase64String(keyBase64);
         if (_key.Length != 32)
+        {
             throw new InvalidOperationException("Encryption key must be exactly 256 bits (32 bytes).");
+        }
     }
 
     public string Encrypt(string plaintext)
@@ -48,7 +52,9 @@ public sealed class AesGcmTokenEncryptionService : ITokenEncryptionService
         var combined = Convert.FromBase64String(ciphertextBase64);
 
         if (combined.Length < NonceSizeBytes + TagSizeBytes)
+        {
             throw new CryptographicException("Invalid ciphertext: too short.");
+        }
 
         var nonce = combined[..NonceSizeBytes];
         var ciphertext = combined[NonceSizeBytes..^TagSizeBytes];

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/GoogleOAuthService.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/GoogleOAuthService.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using FamilyHub.Api.Features.GoogleIntegration.Models;

--- a/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/TokenRefreshBackgroundService.cs
+++ b/src/FamilyHub.Api/Features/GoogleIntegration/Infrastructure/Services/TokenRefreshBackgroundService.cs
@@ -43,7 +43,10 @@ public sealed class TokenRefreshBackgroundService(
         var expiringBefore = DateTime.UtcNow.AddMinutes(_options.RefreshBeforeExpiryMinutes);
         var expiringLinks = await linkRepository.GetExpiringTokensAsync(expiringBefore, ct);
 
-        if (expiringLinks.Count == 0) return;
+        if (expiringLinks.Count == 0)
+        {
+            return;
+        }
 
         logger.LogInformation("Found {Count} Google tokens to refresh", expiringLinks.Count);
 

--- a/src/FamilyHub.Api/Features/Messaging/Application/Search/MessagingSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/Messaging/Application/Search/MessagingSearchProvider.cs
@@ -12,7 +12,9 @@ public sealed class MessagingSearchProvider(IMessageRepository messageRepository
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null || string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         var messages = await messageRepository.GetByFamilyAsync(
             context.FamilyId.Value, limit: 100, ct: cancellationToken);

--- a/src/FamilyHub.Api/Features/Photos/Application/Search/PhotosSearchProvider.cs
+++ b/src/FamilyHub.Api/Features/Photos/Application/Search/PhotosSearchProvider.cs
@@ -12,7 +12,9 @@ public sealed class PhotosSearchProvider(IPhotoRepository photoRepository) : ISe
         CancellationToken cancellationToken = default)
     {
         if (context.FamilyId is null || string.IsNullOrWhiteSpace(context.Query))
+        {
             return [];
+        }
 
         // PhotoRepository already filters out deleted photos
         var photos = await photoRepository.GetByFamilyAsync(

--- a/src/FamilyHub.Api/Features/Photos/GraphQL/PhotoQueries.cs
+++ b/src/FamilyHub.Api/Features/Photos/GraphQL/PhotoQueries.cs
@@ -24,7 +24,7 @@ public class PhotoQueries
             skip,
             Math.Min(take, 30));
 
-        return await queryBus.QueryAsync<PhotosPageDto>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 
     [Authorize]
@@ -34,7 +34,7 @@ public class PhotoQueries
         CancellationToken ct)
     {
         var query = new GetPhotoQuery(PhotoId.From(id));
-        return await queryBus.QueryAsync<PhotoDto?>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 
     [Authorize]
@@ -50,6 +50,6 @@ public class PhotoQueries
             PhotoId.From(currentPhotoId),
             currentCreatedAt);
 
-        return await queryBus.QueryAsync<AdjacentPhotosDto>(query, ct);
+        return await queryBus.QueryAsync(query, ct);
     }
 }

--- a/src/FamilyHub.Api/Features/Photos/Infrastructure/Repositories/PhotoRepository.cs
+++ b/src/FamilyHub.Api/Features/Photos/Infrastructure/Repositories/PhotoRepository.cs
@@ -1,6 +1,5 @@
 using FamilyHub.Api.Common.Database;
 using FamilyHub.Api.Features.FileManagement.Domain.Entities;
-using FamilyHub.Api.Features.FileManagement.Domain.ValueObjects;
 using FamilyHub.Api.Features.Photos.Domain.Repositories;
 using FamilyHub.Api.Features.Photos.Models;
 using FamilyHub.Common.Domain.ValueObjects;

--- a/src/FamilyHub.Api/Features/Search/Application/Queries/UniversalSearch/QueryType.cs
+++ b/src/FamilyHub.Api/Features/Search/Application/Queries/UniversalSearch/QueryType.cs
@@ -28,7 +28,9 @@ public class QueryType
         var user = await userRepository.GetByExternalIdAsync(
             ExternalUserId.From(externalUserIdString), cancellationToken);
         if (user is null)
+        {
             throw new UnauthorizedAccessException("User not found");
+        }
 
         // Resolve permissions from family membership
         string[]? permissions = null;

--- a/src/FamilyHub.Api/Features/Search/Application/Queries/UniversalSearch/UniversalSearchQueryHandler.cs
+++ b/src/FamilyHub.Api/Features/Search/Application/Queries/UniversalSearch/UniversalSearchQueryHandler.cs
@@ -1,7 +1,6 @@
 using FamilyHub.Api.Common.Search;
 using FamilyHub.Common.Application;
 using FamilyHub.Api.Features.Search.Models;
-using Microsoft.Extensions.Logging;
 
 namespace FamilyHub.Api.Features.Search.Application.Queries.UniversalSearch;
 
@@ -73,7 +72,9 @@ public sealed class UniversalSearchQueryHandler(
     private static bool MatchesKeyword(CommandDescriptor command, string query)
     {
         if (string.IsNullOrWhiteSpace(query))
+        {
             return true;
+        }
 
         return command.Label.Contains(query, StringComparison.OrdinalIgnoreCase) ||
                command.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||

--- a/src/FamilyHub.Api/Program.cs
+++ b/src/FamilyHub.Api/Program.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using FamilyHub.Common.Application;
 using FamilyHub.Api.Common.Database;
 using FamilyHub.Api.Common.Infrastructure;


### PR DESCRIPTION
## Summary
- Add universal search with command palette supporting cross-module search across Calendar, Dashboard, EventChain, Family, FileManagement, Messaging, and Photos
- Implement `ISearchProvider` pattern with per-module search providers and NLP-style query hints
- Add default command palette items with navigation shortcuts
- Enforce consistent code style (braces on single-line conditionals, switch expressions, unused using cleanup)

## Commits
- `feat(search): add universal search command palette with auth stabilization`
- `feat(search): add default command palette items with NLP hints and navigation`
- `fix(search): pass logger to UniversalSearchQueryHandler in tests and fix lockfile`
- `fix(search): pass logger to remaining test instantiation site`
- `style: enforce braces on single-line if/else blocks and clean up code style`

## Test plan
- [ ] Verify universal search GraphQL query returns results across all modules
- [ ] Verify default command palette items are returned when no query is provided
- [ ] Verify existing tests pass (`dotnet test`)
- [ ] Verify auth flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)